### PR TITLE
Reduce log level from `info` to `debug`

### DIFF
--- a/examples/ckf_high_dimensional.rs
+++ b/examples/ckf_high_dimensional.rs
@@ -21,56 +21,56 @@ impl NonlinearSystem<f64> for HighDimensionalSystem {
             state[5] * (1.0 - 0.1 * dt) + 0.05 * state[3].sin() * dt,
         ]
     }
-    
+
     fn measurement(&self, state: &[f64]) -> Vec<f64> {
         // Nonlinear measurements of positions
         vec![
-            (state[0].powi(2) + state[1].powi(2)).sqrt(),  // Distance from origin in XY
-            (state[1].powi(2) + state[2].powi(2)).sqrt(),  // Distance from origin in YZ
-            state[0] + state[1] + state[2],                // Sum of positions
+            (state[0].powi(2) + state[1].powi(2)).sqrt(), // Distance from origin in XY
+            (state[1].powi(2) + state[2].powi(2)).sqrt(), // Distance from origin in YZ
+            state[0] + state[1] + state[2],               // Sum of positions
         ]
     }
-    
+
     fn state_jacobian(&self, _state: &[f64], _control: Option<&[f64]>, _dt: f64) -> Vec<f64> {
         unreachable!("CKF doesn't need Jacobians")
     }
-    
+
     fn measurement_jacobian(&self, _state: &[f64]) -> Vec<f64> {
         unreachable!("CKF doesn't need Jacobians")
     }
-    
-    fn state_dim(&self) -> usize { 6 }
-    fn measurement_dim(&self) -> usize { 3 }
+
+    fn state_dim(&self) -> usize {
+        6
+    }
+    fn measurement_dim(&self) -> usize {
+        3
+    }
 }
 
 fn main() {
     println!("=== CKF High-Dimensional System Example ===\n");
-    
+
     let system = HighDimensionalSystem;
-    
+
     // Initial 6D state: [x, y, z, vx, vy, vz]
     let initial_state = vec![1.0, 0.5, -0.5, 0.1, 0.2, -0.1];
-    
+
     // Initial covariance (6x6 identity scaled)
     let mut initial_covariance = vec![0.0; 36];
     for i in 0..6 {
         initial_covariance[i * 6 + i] = 0.1;
     }
-    
+
     // Process noise (6x6 diagonal)
     let mut process_noise = vec![0.0; 36];
     for i in 0..3 {
-        process_noise[i * 6 + i] = 0.01;        // Position noise
-        process_noise[(i+3) * 6 + (i+3)] = 0.001; // Velocity noise
+        process_noise[i * 6 + i] = 0.01; // Position noise
+        process_noise[(i + 3) * 6 + (i + 3)] = 0.001; // Velocity noise
     }
-    
+
     // Measurement noise (3x3 diagonal)
-    let measurement_noise = vec![
-        0.05, 0.0, 0.0,
-        0.0, 0.05, 0.0,
-        0.0, 0.0, 0.02,
-    ];
-    
+    let measurement_noise = vec![0.05, 0.0, 0.0, 0.0, 0.05, 0.0, 0.0, 0.0, 0.02];
+
     // Create CKF
     let mut ckf = CubatureKalmanFilter::new(
         system,
@@ -79,57 +79,69 @@ fn main() {
         process_noise,
         measurement_noise,
         0.1, // dt = 0.1 seconds
-    ).unwrap();
-    
+    )
+    .unwrap();
+
     println!("6D State tracking with CKF (2n = 12 cubature points)");
-    println!("Initial state: [{:.2}, {:.2}, {:.2}, {:.2}, {:.2}, {:.2}]",
-        ckf.state()[0], ckf.state()[1], ckf.state()[2],
-        ckf.state()[3], ckf.state()[4], ckf.state()[5]);
-    
+    println!(
+        "Initial state: [{:.2}, {:.2}, {:.2}, {:.2}, {:.2}, {:.2}]",
+        ckf.state()[0],
+        ckf.state()[1],
+        ckf.state()[2],
+        ckf.state()[3],
+        ckf.state()[4],
+        ckf.state()[5]
+    );
+
     // Track for 20 time steps
     println!("\nTime | Meas 1 | Meas 2 | Meas 3 | State Norm | Cov Trace");
     println!("-----|--------|--------|--------|------------|----------");
-    
+
     for t in 1..=20 {
         // Predict
         ckf.predict().unwrap();
-        
+
         // Generate simulated measurements
         let state = ckf.state();
         let true_meas1 = (state[0].powi(2) + state[1].powi(2)).sqrt();
         let true_meas2 = (state[1].powi(2) + state[2].powi(2)).sqrt();
         let true_meas3 = state[0] + state[1] + state[2];
-        
+
         // Add noise
         let measurements = vec![
             true_meas1 + 0.02 * (t as f64 * 0.3).sin(),
             true_meas2 + 0.02 * (t as f64 * 0.5).cos(),
             true_meas3 + 0.01 * (t as f64 * 0.7).sin(),
         ];
-        
+
         // Update
         ckf.update(&measurements).unwrap();
-        
+
         // Compute state norm and covariance trace
         let state = ckf.state();
         let state_norm: f64 = state.iter().map(|x| x * x).sum::<f64>().sqrt();
-        
+
         let cov = ckf.covariance();
         let cov_trace: f64 = (0..6).map(|i| cov[i * 6 + i]).sum();
-        
-        println!("{:4} | {:6.3} | {:6.3} | {:6.3} | {:10.3} | {:9.4}",
-            t, measurements[0], measurements[1], measurements[2],
-            state_norm, cov_trace);
+
+        println!(
+            "{:4} | {:6.3} | {:6.3} | {:6.3} | {:10.3} | {:9.4}",
+            t, measurements[0], measurements[1], measurements[2], state_norm, cov_trace
+        );
     }
-    
+
     // Final state
     let final_state = ckf.state();
     println!("\nFinal state estimate:");
-    println!("  Position: [{:.3}, {:.3}, {:.3}]",
-        final_state[0], final_state[1], final_state[2]);
-    println!("  Velocity: [{:.3}, {:.3}, {:.3}]",
-        final_state[3], final_state[4], final_state[5]);
-    
+    println!(
+        "  Position: [{:.3}, {:.3}, {:.3}]",
+        final_state[0], final_state[1], final_state[2]
+    );
+    println!(
+        "  Velocity: [{:.3}, {:.3}, {:.3}]",
+        final_state[3], final_state[4], final_state[5]
+    );
+
     println!("\n✓ CKF successfully handled 6D nonlinear system");
     println!("  Used only 12 cubature points (vs 13 sigma points for UKF)");
 }

--- a/examples/enkf_weather_model.rs
+++ b/examples/enkf_weather_model.rs
@@ -18,25 +18,25 @@ impl NonlinearSystem<f64> for Lorenz96Model {
     fn state_transition(&self, state: &[f64], _control: Option<&[f64]>, dt: f64) -> Vec<f64> {
         let n = self.n;
         let mut dxdt = vec![0.0; n];
-        
+
         // Lorenz-96 dynamics: dx_i/dt = (x_{i+1} - x_{i-2}) * x_{i-1} - x_i + F
         for i in 0..n {
             let im2 = if i >= 2 { i - 2 } else { n + i - 2 };
             let im1 = if i >= 1 { i - 1 } else { n - 1 };
             let ip1 = (i + 1) % n;
-            
+
             dxdt[i] = (state[ip1] - state[im2]) * state[im1] - state[i] + self.forcing;
         }
-        
+
         // Euler integration
         let mut new_state = vec![0.0; n];
         for i in 0..n {
             new_state[i] = state[i] + dxdt[i] * dt;
         }
-        
+
         new_state
     }
-    
+
     fn measurement(&self, state: &[f64]) -> Vec<f64> {
         // Observe every other grid point
         let mut obs = Vec::new();
@@ -45,46 +45,50 @@ impl NonlinearSystem<f64> for Lorenz96Model {
         }
         obs
     }
-    
+
     fn state_jacobian(&self, _state: &[f64], _control: Option<&[f64]>, _dt: f64) -> Vec<f64> {
         unreachable!("EnKF doesn't need Jacobians")
     }
-    
+
     fn measurement_jacobian(&self, _state: &[f64]) -> Vec<f64> {
         unreachable!("EnKF doesn't need Jacobians")
     }
-    
-    fn state_dim(&self) -> usize { self.n }
-    fn measurement_dim(&self) -> usize { self.n / 2 }
+
+    fn state_dim(&self) -> usize {
+        self.n
+    }
+    fn measurement_dim(&self) -> usize {
+        self.n / 2
+    }
 }
 
 fn main() {
     println!("=== EnKF Weather Model Data Assimilation Example ===\n");
-    
+
     // Create Lorenz-96 model with 40 grid points (typical test case)
     let n = 40;
     let system = Lorenz96Model { n, forcing: 8.0 };
-    
+
     // Initial mean state (small perturbation from equilibrium)
     let mut initial_mean = vec![8.0; n];
-    initial_mean[n/2] = 8.01; // Small perturbation
-    
+    initial_mean[n / 2] = 8.01; // Small perturbation
+
     // Initial spread
     let initial_spread = vec![0.1; n];
-    
+
     // Process noise (40x40 diagonal matrix)
     let mut process_noise = vec![0.0; n * n];
     for i in 0..n {
         process_noise[i * n + i] = 0.01;
     }
-    
+
     // Measurement noise (20x20 diagonal matrix for observing half the points)
     let m = n / 2;
     let mut measurement_noise = vec![0.0; m * m];
     for i in 0..m {
         measurement_noise[i * m + i] = 0.1;
     }
-    
+
     // Create EnKF with 50 ensemble members
     let ensemble_size = 50;
     let mut enkf = EnsembleKalmanFilter::new(
@@ -95,62 +99,77 @@ fn main() {
         process_noise,
         measurement_noise,
         0.005, // dt = 0.005 (model time units)
-    ).unwrap();
-    
+    )
+    .unwrap();
+
     // Set inflation to maintain ensemble spread
     enkf.set_inflation(1.02);
-    
+
     println!("Lorenz-96 model with {} grid points", n);
     println!("Observing {} locations (every other point)", m);
     println!("Ensemble size: {} members", ensemble_size);
     println!("\nAssimilating observations over time:");
     println!("Time | Ensemble Mean Energy | Ensemble Spread | ESS");
     println!("-----|---------------------|-----------------|--------");
-    
+
     // Run data assimilation for 100 time steps
     for t in 1..=100 {
         // Forecast step
         enkf.forecast();
-        
+
         // Generate synthetic observations (truth + noise)
         let ensemble_mean = enkf.mean();
         let mut observations = Vec::new();
         for i in (0..n).step_by(2) {
             observations.push(ensemble_mean[i] + 0.1 * ((t as f64) * 0.1).sin());
         }
-        
+
         // Analysis step (update with observations)
         enkf.update(&observations).unwrap();
-        
+
         // Compute diagnostics
         let mean = enkf.mean();
         let spread = enkf.spread();
-        
+
         // Energy (sum of squares)
         let energy: f64 = mean.iter().map(|x| x * x).sum::<f64>() / n as f64;
-        
+
         // Average spread
         let avg_spread: f64 = spread.iter().sum::<f64>() / n as f64;
-        
+
         // Print every 10 steps
         if t % 10 == 0 {
-            println!("{:4} | {:19.3} | {:15.3} | {:6.1}",
-                t, energy, avg_spread, ensemble_size as f64);
+            println!(
+                "{:4} | {:19.3} | {:15.3} | {:6.1}",
+                t, energy, avg_spread, ensemble_size as f64
+            );
         }
     }
-    
+
     // Final statistics
     let final_mean = enkf.mean();
     let final_spread = enkf.spread();
-    
+
     println!("\nFinal state statistics:");
-    println!("  Mean state range: [{:.2}, {:.2}]",
+    println!(
+        "  Mean state range: [{:.2}, {:.2}]",
         final_mean.iter().fold(f64::INFINITY, |a, &b| a.min(b)),
-        final_mean.iter().fold(f64::NEG_INFINITY, |a, &b| a.max(b)));
-    println!("  Average uncertainty: {:.3}",
-        final_spread.iter().sum::<f64>() / n as f64);
-    
-    println!("\n✓ EnKF successfully assimilated data in {}-dimensional system", n);
-    println!("  Used only {} ensemble members (vs {} x {} = {} for full covariance)",
-        ensemble_size, n, n, n * n);
+        final_mean.iter().fold(f64::NEG_INFINITY, |a, &b| a.max(b))
+    );
+    println!(
+        "  Average uncertainty: {:.3}",
+        final_spread.iter().sum::<f64>() / n as f64
+    );
+
+    println!(
+        "\n✓ EnKF successfully assimilated data in {}-dimensional system",
+        n
+    );
+    println!(
+        "  Used only {} ensemble members (vs {} x {} = {} for full covariance)",
+        ensemble_size,
+        n,
+        n,
+        n * n
+    );
 }

--- a/examples/if_sensor_network.rs
+++ b/examples/if_sensor_network.rs
@@ -1,15 +1,12 @@
 //! Distributed sensor network example using Information Filter
-//! 
+//!
 //! This example demonstrates a 20-node sensor network tracking a moving target.
 //! Each sensor has limited range and can only communicate with neighbors.
 //! The Information Filter enables efficient distributed fusion.
 #![allow(unused, non_snake_case)] // DO NOT CHANGE!
 
 use kalman_filters::information::{
-    DistributedInformationFilter, 
-    AverageConsensus, 
-    ConsensusAlgorithm,
-    InformationForm,
+    AverageConsensus, ConsensusAlgorithm, DistributedInformationFilter, InformationForm,
 };
 use rand::Rng;
 use std::collections::HashMap;
@@ -19,28 +16,28 @@ fn main() {
     println!("Distributed Sensor Network with Information Filter");
     println!("==================================================");
     println!("20 sensors tracking a moving target\n");
-    
+
     // Network parameters
     const NUM_SENSORS: usize = 20;
     const GRID_SIZE: f64 = 100.0;
     const SENSOR_RANGE: f64 = 30.0;
     const COMM_RANGE: f64 = 40.0;
-    
+
     // Target parameters
-    let target_speed = 5.0;  // m/s
-    let dt = 0.5;  // Time step
-    
+    let target_speed = 5.0; // m/s
+    let dt = 0.5; // Time step
+
     // State: [x, y, vx, vy] - position and velocity
     let state_dim = 4;
-    
+
     // Create distributed filter
     let mut dif = DistributedInformationFilter::<f64>::new(state_dim);
-    
+
     // Place sensors in a grid
     let mut sensor_positions = Vec::new();
     let grid_size = ((NUM_SENSORS as f64).sqrt().ceil()) as usize;
     let grid_spacing = GRID_SIZE / grid_size as f64;
-    
+
     for i in 0..grid_size {
         for j in 0..grid_size {
             if sensor_positions.len() < NUM_SENSORS {
@@ -50,34 +47,35 @@ fn main() {
             }
         }
     }
-    
+
     println!("Sensor Network Configuration:");
-    println!("- {} sensors in {}x{} grid", NUM_SENSORS, grid_size, grid_size);
+    println!(
+        "- {} sensors in {}x{} grid",
+        NUM_SENSORS, grid_size, grid_size
+    );
     println!("- Sensing range: {} m", SENSOR_RANGE);
     println!("- Communication range: {} m", COMM_RANGE);
-    
+
     // Initialize nodes with weak prior
-    let weak_info = 0.001;  // Weak prior information
+    let weak_info = 0.001; // Weak prior information
     for i in 0..NUM_SENSORS {
         let Y_init = vec![
-            weak_info, 0.0, 0.0, 0.0,
-            0.0, weak_info, 0.0, 0.0,
-            0.0, 0.0, weak_info, 0.0,
-            0.0, 0.0, 0.0, weak_info,
+            weak_info, 0.0, 0.0, 0.0, 0.0, weak_info, 0.0, 0.0, 0.0, 0.0, weak_info, 0.0, 0.0, 0.0,
+            0.0, weak_info,
         ];
         let y_init = vec![0.0, 0.0, 0.0, 0.0];
-        
+
         dif.add_node(i, Y_init, y_init).unwrap();
     }
-    
+
     // Connect nodes within communication range
     let mut num_connections = 0;
     for i in 0..sensor_positions.len() {
-        for j in i+1..sensor_positions.len() {
+        for j in i + 1..sensor_positions.len() {
             let (x1, y1) = sensor_positions[i];
             let (x2, y2) = sensor_positions[j];
             let dist = ((x2 - x1).powi(2) + (y2 - y1).powi(2)).sqrt();
-            
+
             if dist <= COMM_RANGE {
                 // Add small random delay (0-2 time steps)
                 let delay = rand::thread_rng().gen_range(0..3);
@@ -86,93 +84,98 @@ fn main() {
             }
         }
     }
-    
+
     println!("- {} communication links established", num_connections);
-    
+
     // Target trajectory (circular motion)
     let mut rng = rand::thread_rng();
     let center_x = GRID_SIZE / 2.0;
     let center_y = GRID_SIZE / 2.0;
     let radius = GRID_SIZE / 3.0;
-    let omega = 0.1;  // Angular velocity
-    
+    let omega = 0.1; // Angular velocity
+
     println!("\nSimulation Results:");
     println!("Time | True X | True Y | Sensors | Consensus X | Consensus Y | Error");
     println!("-----|--------|--------|---------|-------------|-------------|-------");
-    
+
     // Simulation loop
     for step in 0..20 {
         let t = step as f64 * dt;
-        
+
         // True target position
         let true_x = center_x + radius * (omega * t).cos();
         let true_y = center_y + radius * (omega * t).sin();
         let true_vx = -radius * omega * (omega * t).sin();
         let true_vy = radius * omega * (omega * t).cos();
-        
+
         // Sensors that can see the target
         let mut detecting_sensors = Vec::new();
-        
+
         for (sensor_id, &(sx, sy)) in sensor_positions.iter().enumerate() {
             let dist_to_target = ((true_x - sx).powi(2) + (true_y - sy).powi(2)).sqrt();
-            
+
             if dist_to_target <= SENSOR_RANGE {
                 detecting_sensors.push(sensor_id);
-                
+
                 // Generate noisy measurement
-                let noise_std = 1.0 + dist_to_target * 0.1;  // Distance-dependent noise
+                let noise_std = 1.0 + dist_to_target * 0.1; // Distance-dependent noise
                 let meas_x = true_x + rng.gen_range(-noise_std..noise_std);
                 let meas_y = true_y + rng.gen_range(-noise_std..noise_std);
-                
+
                 // Observation matrix (position only)
-                let H = vec![
-                    1.0, 0.0, 0.0, 0.0,
-                    0.0, 1.0, 0.0, 0.0,
-                ];
-                
+                let H = vec![1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0];
+
                 // Measurement noise (distance-dependent)
                 let r_val = noise_std.powi(2);
-                let R = vec![
-                    r_val, 0.0,
-                    0.0, r_val,
-                ];
-                
+                let R = vec![r_val, 0.0, 0.0, r_val];
+
                 // Local update
-                dif.local_update(sensor_id, &[meas_x, meas_y], &H, &R).unwrap();
+                dif.local_update(sensor_id, &[meas_x, meas_y], &H, &R)
+                    .unwrap();
             }
         }
-        
+
         // Process messages (information propagation)
-        for _ in 0..3 {  // Multiple rounds for better convergence
+        for _ in 0..3 {
+            // Multiple rounds for better convergence
             dif.process_messages().unwrap();
         }
-        
+
         // Run consensus algorithm
         let topology = dif.topology.clone();
         let mut local_states = HashMap::new();
         for (node_id, node) in &dif.nodes {
             local_states.insert(*node_id, node.local_state.clone());
         }
-        
+
         let mut consensus = AverageConsensus::<f64>::new_metropolis(&topology, state_dim);
-        for _ in 0..5 {  // Consensus iterations
+        for _ in 0..5 {
+            // Consensus iterations
             consensus.iterate(&mut local_states, &topology).unwrap();
         }
-        
+
         // Get consensus estimate
         if let Some(consensus_state) = consensus.get_consensus() {
             if let Ok(state) = consensus_state.recover_state() {
                 let error = ((state[0] - true_x).powi(2) + (state[1] - true_y).powi(2)).sqrt();
-                
-                if step % 2 == 0 {  // Print every other step
-                    println!("{:4.1} | {:6.1} | {:6.1} | {:7} | {:11.1} | {:11.1} | {:6.2}",
-                            t, true_x, true_y, detecting_sensors.len(),
-                            state[0], state[1], error);
+
+                if step % 2 == 0 {
+                    // Print every other step
+                    println!(
+                        "{:4.1} | {:6.1} | {:6.1} | {:7} | {:11.1} | {:11.1} | {:6.2}",
+                        t,
+                        true_x,
+                        true_y,
+                        detecting_sensors.len(),
+                        state[0],
+                        state[1],
+                        error
+                    );
                 }
             }
         }
     }
-    
+
     // Network statistics
     let stats = dif.get_network_stats();
     println!("\nNetwork Statistics:");
@@ -180,34 +183,33 @@ fn main() {
     println!("- Edges: {}", stats.num_edges);
     println!("- Average degree: {:.1}", stats.avg_degree);
     println!("- Maximum degree: {}", stats.max_degree);
-    
+
     println!("\nDistributed Information Filter successfully tracked target");
     println!("across sparse sensor network with limited communication.");
 
-    
     multi_rate_example();
 }
 
 /// Simulate node failures
 fn simulate_node_failure(dif: &mut DistributedInformationFilter<f64>, failed_nodes: Vec<usize>) {
     println!("\nSimulating node failures: {:?}", failed_nodes);
-    
+
     for node_id in failed_nodes {
         // Remove node from network
         if dif.nodes.remove(&node_id).is_some() {
             // Remove from topology
             dif.topology.remove(&node_id);
-            
+
             // Remove connections to failed node
             for neighbors in dif.topology.values_mut() {
                 neighbors.retain(|&n| n != node_id);
             }
-            
+
             // Update remaining nodes' neighbor lists
             for node in dif.nodes.values_mut() {
                 node.neighbors.retain(|&n| n != node_id);
             }
-            
+
             println!("Node {} failed and removed from network", node_id);
         }
     }
@@ -217,106 +219,102 @@ fn simulate_node_failure(dif: &mut DistributedInformationFilter<f64>, failed_nod
 fn multi_rate_example() {
     println!("\n\nMulti-Rate Sensor Fusion Example");
     println!("=================================");
-    
+
     // Different sensor types with different update rates
     // - GPS: 1 Hz (slow, accurate position)
     // - IMU: 100 Hz (fast, acceleration)
     // - Camera: 10 Hz (medium, position)
-    
-    let mut dif = DistributedInformationFilter::<f64>::new(6);  // [x, y, z, vx, vy, vz]
-    
+
+    let mut dif = DistributedInformationFilter::<f64>::new(6); // [x, y, z, vx, vy, vz]
+
     // Initialize 3 sensor nodes
     let info_init = 0.001;
     let Y_init = vec![info_init; 36];
     let y_init = vec![0.0; 6];
-    
+
     // Node 0: GPS
     dif.add_node(0, Y_init.clone(), y_init.clone()).unwrap();
     // Node 1: IMU
     dif.add_node(1, Y_init.clone(), y_init.clone()).unwrap();
     // Node 2: Camera
     dif.add_node(2, Y_init.clone(), y_init.clone()).unwrap();
-    
+
     // Fully connected network
     dif.connect_nodes(0, 1, 0).unwrap();
     dif.connect_nodes(0, 2, 0).unwrap();
     dif.connect_nodes(1, 2, 0).unwrap();
-    
+
     println!("3-node network with different sensor types:");
     println!("- Node 0: GPS (1 Hz)");
     println!("- Node 1: IMU (100 Hz)");
     println!("- Node 2: Camera (10 Hz)");
-    
+
     // Simulate 1 second of data
     let mut time = 0.0;
-    let dt = 0.01;  // 100 Hz base rate
-    
+    let dt = 0.01; // 100 Hz base rate
+
     while time < 1.0 {
         let time_ms = (time * 1000.0) as u32;
-        
+
         // GPS updates every 1000ms
         if time_ms % 1000 == 0 {
             let H = vec![
-                1.0, 0.0, 0.0, 0.0, 0.0, 0.0,  // x
-                0.0, 1.0, 0.0, 0.0, 0.0, 0.0,  // y
-                0.0, 0.0, 1.0, 0.0, 0.0, 0.0,  // z
+                1.0, 0.0, 0.0, 0.0, 0.0, 0.0, // x
+                0.0, 1.0, 0.0, 0.0, 0.0, 0.0, // y
+                0.0, 0.0, 1.0, 0.0, 0.0, 0.0, // z
             ];
             let R = vec![
-                1.0, 0.0, 0.0,
-                0.0, 1.0, 0.0,
-                0.0, 0.0, 2.0,  // Worse vertical accuracy
+                1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 2.0, // Worse vertical accuracy
             ];
             let measurement = vec![10.0, 20.0, 5.0];
             dif.local_update(0, &measurement, &H, &R).unwrap();
         }
-        
+
         // IMU updates every 10ms (100 Hz)
         if time_ms % 10 == 0 {
             // IMU measures acceleration (affects velocity)
             let H = vec![
-                0.0, 0.0, 0.0, 1.0, 0.0, 0.0,  // vx
-                0.0, 0.0, 0.0, 0.0, 1.0, 0.0,  // vy
-                0.0, 0.0, 0.0, 0.0, 0.0, 1.0,  // vz
+                0.0, 0.0, 0.0, 1.0, 0.0, 0.0, // vx
+                0.0, 0.0, 0.0, 0.0, 1.0, 0.0, // vy
+                0.0, 0.0, 0.0, 0.0, 0.0, 1.0, // vz
             ];
-            let R = vec![
-                0.01, 0.0, 0.0,
-                0.0, 0.01, 0.0,
-                0.0, 0.0, 0.01,
-            ];
+            let R = vec![0.01, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0, 0.0, 0.01];
             let measurement = vec![0.5, 0.2, -0.1];
             dif.local_update(1, &measurement, &H, &R).unwrap();
         }
-        
+
         // Camera updates every 100ms (10 Hz)
         if time_ms % 100 == 0 {
             let H = vec![
-                1.0, 0.0, 0.0, 0.0, 0.0, 0.0,  // x
-                0.0, 1.0, 0.0, 0.0, 0.0, 0.0,  // y
+                1.0, 0.0, 0.0, 0.0, 0.0, 0.0, // x
+                0.0, 1.0, 0.0, 0.0, 0.0, 0.0, // y
             ];
-            let R = vec![
-                0.5, 0.0,
-                0.0, 0.5,
-            ];
+            let R = vec![0.5, 0.0, 0.0, 0.5];
             let measurement = vec![10.5, 20.2];
             dif.local_update(2, &measurement, &H, &R).unwrap();
         }
-        
+
         // Process messages
         dif.process_messages().unwrap();
-        
+
         time += dt;
     }
-    
+
     println!("\nProcessed 1 second of multi-rate sensor data");
     println!("- GPS: 1 update");
     println!("- IMU: 100 updates");
     println!("- Camera: 10 updates");
-    
+
     // Get final consensus
     if let Ok(consensus) = dif.get_consensus_state() {
         println!("\nFinal consensus state:");
-        println!("Position: [{:.2}, {:.2}, {:.2}]", consensus[0], consensus[1], consensus[2]);
-        println!("Velocity: [{:.2}, {:.2}, {:.2}]", consensus[3], consensus[4], consensus[5]);
+        println!(
+            "Position: [{:.2}, {:.2}, {:.2}]",
+            consensus[0], consensus[1], consensus[2]
+        );
+        println!(
+            "Velocity: [{:.2}, {:.2}, {:.2}]",
+            consensus[3], consensus[4], consensus[5]
+        );
     }
 }
-

--- a/examples/logging_demo.rs
+++ b/examples/logging_demo.rs
@@ -17,16 +17,16 @@
 //! cargo run --example logging_demo --features tracing-subscriber
 //! ```
 
-use kalman_filters::{KalmanFilterBuilder, ExtendedKalmanFilter, NonlinearSystem};
-use log::{info, debug, warn};
+use kalman_filters::{ExtendedKalmanFilter, KalmanFilterBuilder, NonlinearSystem};
+use log::{debug, info, warn};
 
 #[cfg(feature = "tracing-subscriber")]
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 /// Simple pendulum system for demonstrating EKF logging
 struct PendulumSystem {
-    g: f64,  // gravity
-    l: f64,  // length
+    g: f64, // gravity
+    l: f64, // length
 }
 
 impl NonlinearSystem<f64> for PendulumSystem {
@@ -38,23 +38,20 @@ impl NonlinearSystem<f64> for PendulumSystem {
             theta_dot - (self.g / self.l) * theta.sin() * dt,
         ]
     }
-    
+
     fn measurement(&self, state: &[f64]) -> Vec<f64> {
         vec![state[0]] // Measure angle only
     }
-    
+
     fn state_jacobian(&self, state: &[f64], _control: Option<&[f64]>, dt: f64) -> Vec<f64> {
         let theta = state[0];
-        vec![
-            1.0, dt,
-            -(self.g / self.l) * theta.cos() * dt, 1.0
-        ]
+        vec![1.0, dt, -(self.g / self.l) * theta.cos() * dt, 1.0]
     }
-    
+
     fn measurement_jacobian(&self, _state: &[f64]) -> Vec<f64> {
         vec![1.0, 0.0]
     }
-    
+
     fn state_dim(&self) -> usize {
         2
     }
@@ -74,31 +71,31 @@ fn main() {
             .init();
         info!("Initialized tracing_subscriber for structured logging");
     }
-    
+
     #[cfg(not(feature = "tracing-subscriber"))]
     {
         // Simple env_logger initialization
         env_logger::init();
         info!("Using env_logger (install tracing-subscriber feature for structured logging)");
     }
-    
+
     info!("Starting Kalman Filter logging demonstration");
-    
+
     // Demonstrate linear Kalman filter logging
     demo_linear_kf();
-    
+
     // Demonstrate Extended Kalman filter logging
     demo_extended_kf();
-    
+
     // Demonstrate numerical stability warnings
     demo_numerical_issues();
-    
+
     info!("Logging demonstration complete");
 }
 
 fn demo_linear_kf() {
     info!("=== Linear Kalman Filter Demo ===");
-    
+
     // Create a simple 1D Kalman filter using the builder
     let mut kf = KalmanFilterBuilder::<f64>::new(1, 1)
         .initial_state(vec![0.0])
@@ -109,16 +106,16 @@ fn demo_linear_kf() {
         .measurement_noise(vec![0.1])
         .build()
         .unwrap();
-    
+
     debug!("Running predict/update cycle");
-    
+
     // Run a few cycles
     for i in 1..=3 {
         info!("Cycle {}", i);
-        
+
         // Predict
         kf.predict();
-        
+
         // Update with measurement
         let measurement = vec![i as f64 * 0.5];
         kf.update(&measurement).unwrap();
@@ -127,32 +124,34 @@ fn demo_linear_kf() {
 
 fn demo_extended_kf() {
     info!("=== Extended Kalman Filter Demo ===");
-    
-    let system = PendulumSystem {
-        g: 9.81,
-        l: 1.0,
-    };
-    
+
+    let system = PendulumSystem { g: 9.81, l: 1.0 };
+
     let mut ekf: ExtendedKalmanFilter<f64, PendulumSystem> = ExtendedKalmanFilter::new(
         system,
-        vec![0.1, 0.0],      // initial state [angle, angular_velocity]
-        vec![0.01, 0.0,      // initial covariance
-             0.0, 0.01],
-        vec![0.001, 0.0,     // process noise
-             0.0, 0.001],
-        vec![0.1],           // measurement noise
-        0.01,                // dt
-    ).unwrap();
-    
+        vec![0.1, 0.0], // initial state [angle, angular_velocity]
+        vec![
+            0.01, 0.0, // initial covariance
+            0.0, 0.01,
+        ],
+        vec![
+            0.001, 0.0, // process noise
+            0.0, 0.001,
+        ],
+        vec![0.1], // measurement noise
+        0.01,      // dt
+    )
+    .unwrap();
+
     debug!("Running EKF predict/update cycle");
-    
+
     // Run a few cycles
     for i in 1..=3 {
         info!("EKF Cycle {}", i);
-        
+
         // Predict
         ekf.predict();
-        
+
         // Update with measurement
         let measurement = vec![0.05 * i as f64];
         ekf.update(&measurement).unwrap();
@@ -161,41 +160,41 @@ fn demo_extended_kf() {
 
 fn demo_numerical_issues() {
     info!("=== Numerical Stability Demo ===");
-    
+
     // Create a filter with near-singular covariance
     let mut kf = KalmanFilterBuilder::<f64>::new(2, 1)
         .initial_state(vec![0.0, 0.0])
-        .initial_covariance(vec![1e-12, 0.0, 0.0, 1e-12])  // near-singular
+        .initial_covariance(vec![1e-12, 0.0, 0.0, 1e-12]) // near-singular
         .transition_matrix(vec![1.0, 0.1, 0.0, 1.0])
         .process_noise(vec![0.001, 0.0, 0.0, 0.001])
         .observation_matrix(vec![1.0, 0.0])
         .measurement_noise(vec![0.1])
         .build()
         .unwrap();
-    
+
     warn!("Created filter with near-singular covariance to trigger warnings");
-    
+
     // This should trigger numerical stability warnings
     kf.predict();
-    
+
     // Try to update - may trigger warnings about innovation covariance
     let _ = kf.update(&[1.0]);
-    
+
     // Create a filter that will have a singular innovation covariance
     let mut bad_kf = KalmanFilterBuilder::<f64>::new(2, 2)
         .initial_state(vec![0.0, 0.0])
-        .initial_covariance(vec![0.0, 0.0, 0.0, 0.0])  // zero covariance!
+        .initial_covariance(vec![0.0, 0.0, 0.0, 0.0]) // zero covariance!
         .transition_matrix(vec![1.0, 0.0, 0.0, 1.0])
-        .process_noise(vec![0.0, 0.0, 0.0, 0.0])  // zero process noise
+        .process_noise(vec![0.0, 0.0, 0.0, 0.0]) // zero process noise
         .observation_matrix(vec![1.0, 0.0, 0.0, 1.0])
-        .measurement_noise(vec![0.0, 0.0, 0.0, 0.0])  // zero measurement noise!
+        .measurement_noise(vec![0.0, 0.0, 0.0, 0.0]) // zero measurement noise!
         .build()
         .unwrap();
-    
+
     warn!("Created filter with zero covariances to demonstrate error logging");
-    
+
     bad_kf.predict();
-    
+
     // This should fail with a singular matrix error
     match bad_kf.update(&[1.0, 1.0]) {
         Ok(_) => debug!("Update succeeded unexpectedly"),

--- a/examples/particle_filter_robot.rs
+++ b/examples/particle_filter_robot.rs
@@ -8,21 +8,21 @@ use std::f64::consts::PI;
 
 fn main() {
     println!("=== Particle Filter Robot Localization Example ===\n");
-    
+
     // Robot state: [x, y, theta] (position and heading)
     let state_dim = 3;
     let num_particles = 500;
-    
+
     // Initial uncertainty (robot could be anywhere in a 10x10 area)
     let initial_mean = vec![5.0, 5.0, 0.0];
     let initial_std = vec![3.0, 3.0, PI]; // Large uncertainty
-    
+
     // Process noise (motion uncertainty)
     let process_noise_std = vec![0.1, 0.1, 0.05];
-    
+
     // Measurement noise
     let measurement_noise_std = vec![0.5, 0.5];
-    
+
     // Create particle filter
     let mut pf = ParticleFilter::new(
         state_dim,
@@ -32,117 +32,131 @@ fn main() {
         process_noise_std,
         measurement_noise_std,
         1.0, // dt
-    ).unwrap();
-    
+    )
+    .unwrap();
+
     // Use systematic resampling for better performance
     pf.set_resampling_strategy(ResamplingStrategy::Systematic);
-    
+
     println!("Robot localization with {} particles", num_particles);
     println!("Initial uncertainty: ±3m in position, ±180° in heading\n");
-    
+
     // Known landmarks in the environment
     let landmarks = vec![
-        (2.0, 8.0),   // Landmark 1
-        (8.0, 8.0),   // Landmark 2
-        (8.0, 2.0),   // Landmark 3
-        (2.0, 2.0),   // Landmark 4
+        (2.0, 8.0), // Landmark 1
+        (8.0, 8.0), // Landmark 2
+        (8.0, 2.0), // Landmark 3
+        (2.0, 2.0), // Landmark 4
     ];
-    
+
     println!("Landmarks at: {:?}", landmarks);
-    
+
     // Motion model: simple differential drive robot
     let motion_model = |state: &[f64], dt: f64| -> Vec<f64> {
         let x = state[0];
         let y = state[1];
         let theta = state[2];
-        
+
         // Control inputs (forward velocity and angular velocity)
-        let v = 1.0;  // 1 m/s forward
+        let v = 1.0; // 1 m/s forward
         let omega = 0.1; // 0.1 rad/s turning
-        
+
         vec![
             x + v * theta.cos() * dt,
             y + v * theta.sin() * dt,
             theta + omega * dt,
         ]
     };
-    
+
     // Likelihood function based on landmark observations
     let likelihood_fn = |state: &[f64], measurement: &[f64]| -> f64 {
         let x = state[0];
         let y = state[1];
-        
+
         // Find closest landmark
         let observed_landmark_idx = measurement[0] as usize;
         if observed_landmark_idx >= landmarks.len() {
             return 1e-10;
         }
-        
+
         let (lx, ly) = landmarks[observed_landmark_idx];
         let measured_dist = measurement[1];
-        
+
         // Calculate expected distance
         let expected_dist = ((x - lx).powi(2) + (y - ly).powi(2)).sqrt();
-        
+
         // Gaussian likelihood
         let diff = measured_dist - expected_dist;
         let sigma = 0.5;
         (-0.5 * diff * diff / (sigma * sigma)).exp()
     };
-    
+
     println!("\nTime | Observed | Distance | Est. X | Est. Y | Est. θ | ESS");
     println!("-----|----------|----------|--------|--------|--------|------");
-    
+
     // Simulate robot motion and observations
     for t in 1..=10 {
         // Predict step (motion update)
         pf.predict(motion_model);
-        
+
         // Simulate landmark observation
         let landmark_idx = t % landmarks.len();
         let (lx, ly) = landmarks[landmark_idx];
-        
+
         // True robot position (for simulation)
         let best = pf.best_particle();
         let true_dist = ((best.state[0] - lx).powi(2) + (best.state[1] - ly).powi(2)).sqrt();
-        
+
         // Observed distance with noise
         let observed_dist = true_dist + 0.3 * ((t as f64) * 0.5).sin();
-        
+
         // Update step with measurement
         let measurement = vec![landmark_idx as f64, observed_dist];
         pf.update(&measurement, likelihood_fn).unwrap();
-        
+
         // Get state estimate (weighted mean)
         let state = pf.mean();
         let ess = pf.effective_sample_size();
-        
-        println!("{:4} | L{:7} | {:8.2} | {:6.2} | {:6.2} | {:6.2} | {:4.0}",
-            t, landmark_idx + 1, observed_dist,
-            state[0], state[1], state[2], ess);
+
+        println!(
+            "{:4} | L{:7} | {:8.2} | {:6.2} | {:6.2} | {:6.2} | {:4.0}",
+            t,
+            landmark_idx + 1,
+            observed_dist,
+            state[0],
+            state[1],
+            state[2],
+            ess
+        );
     }
-    
+
     // Final estimate
     let final_state = pf.mean();
     let best_particle = pf.best_particle();
-    
+
     println!("\nFinal estimates:");
-    println!("  Weighted mean: x={:.2}, y={:.2}, θ={:.2}",
-        final_state[0], final_state[1], final_state[2]);
-    println!("  Best particle: x={:.2}, y={:.2}, θ={:.2} (weight={:.3})",
-        best_particle.state[0], best_particle.state[1], best_particle.state[2],
-        best_particle.weight);
-    
+    println!(
+        "  Weighted mean: x={:.2}, y={:.2}, θ={:.2}",
+        final_state[0], final_state[1], final_state[2]
+    );
+    println!(
+        "  Best particle: x={:.2}, y={:.2}, θ={:.2} (weight={:.3})",
+        best_particle.state[0],
+        best_particle.state[1],
+        best_particle.state[2],
+        best_particle.weight
+    );
+
     // Check for multimodality
     let covariance = pf.covariance();
     let position_variance = covariance[0] + covariance[4]; // σ²_x + σ²_y
-    
+
     if position_variance > 2.0 {
         println!("\n⚠ High variance detected - possible multimodal distribution");
         println!("  The robot might be uncertain between multiple locations");
     } else {
         println!("\n✓ Robot successfully localized with particle filter");
     }
-    
+
     println!("  Handled non-Gaussian, potentially multimodal distributions");
 }

--- a/examples/position_2d.rs
+++ b/examples/position_2d.rs
@@ -1,5 +1,5 @@
 //! 2D Position tracking example
-//! 
+//!
 //! This example demonstrates tracking a 2D position (x, y) with velocity.
 //! The state vector contains [x, y, vx, vy] and we measure [x, y].
 //!
@@ -22,52 +22,58 @@ use nalgebra::{SMatrix, SVector};
 fn main() {
     println!("2D Position Tracking with Kalman Filter (Vec-based)");
     println!("====================================================");
-    
+
     // Time step
     let dt = 0.1;
-    
+
     // State transition matrix for 2D constant velocity model
     // State: [x, y, vx, vy]
     let f = vec![
-        1.0, 0.0, dt,  0.0,  // x = x + vx * dt
-        0.0, 1.0, 0.0, dt,   // y = y + vy * dt
-        0.0, 0.0, 1.0, 0.0,  // vx = vx
-        0.0, 0.0, 0.0, 1.0,  // vy = vy
+        1.0, 0.0, dt, 0.0, // x = x + vx * dt
+        0.0, 1.0, 0.0, dt, // y = y + vy * dt
+        0.0, 0.0, 1.0, 0.0, // vx = vx
+        0.0, 0.0, 0.0, 1.0, // vy = vy
     ];
-    
+
     // Initial state: origin with velocity (1, 0.5) m/s
     let x0 = vec![0.0, 0.0, 1.0, 0.5];
-    
+
     // Initial covariance
     let p0 = vec![
-        1.0, 0.0, 0.0, 0.0,
-        0.0, 1.0, 0.0, 0.0,
-        0.0, 0.0, 1.0, 0.0,
-        0.0, 0.0, 0.0, 1.0,
+        1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
     ];
-    
+
     // Process noise (acceleration uncertainty)
-    let q_val = 0.01;  // Process noise strength
+    let q_val = 0.01; // Process noise strength
     let q = vec![
-        q_val*dt*dt*dt/3.0, 0.0, q_val*dt*dt/2.0, 0.0,
-        0.0, q_val*dt*dt*dt/3.0, 0.0, q_val*dt*dt/2.0,
-        q_val*dt*dt/2.0, 0.0, q_val*dt, 0.0,
-        0.0, q_val*dt*dt/2.0, 0.0, q_val*dt,
+        q_val * dt * dt * dt / 3.0,
+        0.0,
+        q_val * dt * dt / 2.0,
+        0.0,
+        0.0,
+        q_val * dt * dt * dt / 3.0,
+        0.0,
+        q_val * dt * dt / 2.0,
+        q_val * dt * dt / 2.0,
+        0.0,
+        q_val * dt,
+        0.0,
+        0.0,
+        q_val * dt * dt / 2.0,
+        0.0,
+        q_val * dt,
     ];
-    
+
     // Observation matrix (we measure x and y positions)
     let h = vec![
-        1.0, 0.0, 0.0, 0.0,  // Measure x
-        0.0, 1.0, 0.0, 0.0,  // Measure y
+        1.0, 0.0, 0.0, 0.0, // Measure x
+        0.0, 1.0, 0.0, 0.0, // Measure y
     ];
-    
+
     // Measurement noise
-    let r_val = 0.1;  // Measurement noise strength
-    let r = vec![
-        r_val, 0.0,
-        0.0, r_val,
-    ];
-    
+    let r_val = 0.1; // Measurement noise strength
+    let r = vec![r_val, 0.0, 0.0, r_val];
+
     // Build the Kalman filter
     let mut kf = KalmanFilterBuilder::<f64>::new(4, 2)
         .initial_state(x0)
@@ -78,54 +84,53 @@ fn main() {
         .measurement_noise(r)
         .build()
         .expect("Failed to build Kalman filter");
-    
+
     // Simulate a moving object with circular motion
     let mut rng = rand::thread_rng();
-    let omega = 0.1;  // Angular velocity for circular motion
+    let omega = 0.1; // Angular velocity for circular motion
     let radius = 5.0;
-    
+
     println!("\nTime |  True X  |  True Y  | Meas. X  | Meas. Y  | Est. X   | Est. Y   | Est. Vx  | Est. Vy");
     println!("-----|----------|----------|----------|----------|----------|----------|----------|--------");
-    
+
     for step in 0..100 {
         let t = step as f64 * dt;
-        
+
         // True position (circular motion)
         let true_x = radius * (omega * t).cos();
         let true_y = radius * (omega * t).sin();
-        
+
         // Generate noisy measurements
         let noise_x = rng.gen_range(-0.3..0.3);
         let noise_y = rng.gen_range(-0.3..0.3);
         let measured_x = true_x + noise_x;
         let measured_y = true_y + noise_y;
-        
+
         // Kalman filter predict step
         kf.predict();
-        
+
         // Kalman filter update step
         kf.update(&[measured_x, measured_y]).expect("Update failed");
-        
+
         // Get estimated state
         let state = kf.state();
-        
+
         // Print results every 20 steps
         if step % 20 == 0 {
             println!(
                 "{:4.1} | {:8.3} | {:8.3} | {:8.3} | {:8.3} | {:8.3} | {:8.3} | {:8.3} | {:7.3}",
-                t, true_x, true_y, measured_x, measured_y,
-                state[0], state[1], state[2], state[3]
+                t, true_x, true_y, measured_x, measured_y, state[0], state[1], state[2], state[3]
             );
         }
     }
-    
+
     println!("\nFinal state covariance (diagonal elements):");
     let p = kf.covariance();
     println!("X position variance:  {:.6}", p[0 * 4 + 0]);
     println!("Y position variance:  {:.6}", p[1 * 4 + 1]);
     println!("X velocity variance:  {:.6}", p[2 * 4 + 2]);
     println!("Y velocity variance:  {:.6}", p[3 * 4 + 3]);
-    
+
     println!("\nThe filter tracked the 2D position and estimated velocities");
     println!("from noisy position measurements.");
 }
@@ -134,22 +139,22 @@ fn main() {
 fn main() {
     println!("2D Position Tracking with Kalman Filter (nalgebra-based)");
     println!("=========================================================");
-    
+
     // Time step
     let dt = 0.1;
-    
+
     // State transition matrix for 2D constant velocity model
     // State: [x, y, vx, vy]
     let F = SMatrix::<f64, 4, 4>::from([
-        [1.0, 0.0, dt,  0.0],  // x = x + vx * dt
-        [0.0, 1.0, 0.0, dt ],  // y = y + vy * dt
-        [0.0, 0.0, 1.0, 0.0],  // vx = vx
-        [0.0, 0.0, 0.0, 1.0],  // vy = vy
+        [1.0, 0.0, dt, 0.0],  // x = x + vx * dt
+        [0.0, 1.0, 0.0, dt],  // y = y + vy * dt
+        [0.0, 0.0, 1.0, 0.0], // vx = vx
+        [0.0, 0.0, 0.0, 1.0], // vy = vy
     ]);
-    
+
     // Initial state: origin with velocity (1, 0.5) m/s
     let x0 = SVector::<f64, 4>::from([0.0, 0.0, 1.0, 0.5]);
-    
+
     // Initial covariance
     let P0 = SMatrix::<f64, 4, 4>::from([
         [1.0, 0.0, 0.0, 0.0],
@@ -157,80 +162,76 @@ fn main() {
         [0.0, 0.0, 1.0, 0.0],
         [0.0, 0.0, 0.0, 1.0],
     ]);
-    
+
     // Process noise (acceleration uncertainty)
-    let q_val = 0.01;  // Process noise strength
+    let q_val = 0.01; // Process noise strength
     let Q = SMatrix::<f64, 4, 4>::from([
-        [q_val*dt*dt*dt/3.0, 0.0, q_val*dt*dt/2.0, 0.0],
-        [0.0, q_val*dt*dt*dt/3.0, 0.0, q_val*dt*dt/2.0],
-        [q_val*dt*dt/2.0, 0.0, q_val*dt, 0.0],
-        [0.0, q_val*dt*dt/2.0, 0.0, q_val*dt],
+        [q_val * dt * dt * dt / 3.0, 0.0, q_val * dt * dt / 2.0, 0.0],
+        [0.0, q_val * dt * dt * dt / 3.0, 0.0, q_val * dt * dt / 2.0],
+        [q_val * dt * dt / 2.0, 0.0, q_val * dt, 0.0],
+        [0.0, q_val * dt * dt / 2.0, 0.0, q_val * dt],
     ]);
-    
+
     // Observation matrix (we measure x and y positions)
     let H = SMatrix::<f64, 2, 4>::from_row_slice(&[
-        1.0, 0.0, 0.0, 0.0,  // Measure x
-        0.0, 1.0, 0.0, 0.0,  // Measure y
+        1.0, 0.0, 0.0, 0.0, // Measure x
+        0.0, 1.0, 0.0, 0.0, // Measure y
     ]);
-    
+
     // Measurement noise
-    let r_val = 0.1;  // Measurement noise strength
-    let R = SMatrix::<f64, 2, 2>::from([
-        [r_val, 0.0],
-        [0.0, r_val],
-    ]);
-    
+    let r_val = 0.1; // Measurement noise strength
+    let R = SMatrix::<f64, 2, 2>::from([[r_val, 0.0], [0.0, r_val]]);
+
     // Create the Kalman filter
     let mut kf = StaticKalmanFilter::new(x0, P0, F, Q, H, R);
-    
+
     // Simulate a moving object with circular motion
     let mut rng = rand::thread_rng();
-    let omega = 0.1;  // Angular velocity for circular motion
+    let omega = 0.1; // Angular velocity for circular motion
     let radius = 5.0;
-    
+
     println!("\nTime |  True X  |  True Y  | Meas. X  | Meas. Y  | Est. X   | Est. Y   | Est. Vx  | Est. Vy");
     println!("-----|----------|----------|----------|----------|----------|----------|----------|--------");
-    
+
     for step in 0..100 {
         let t = step as f64 * dt;
-        
+
         // True position (circular motion)
         let true_x = radius * (omega * t).cos();
         let true_y = radius * (omega * t).sin();
-        
+
         // Generate noisy measurements
         let noise_x = rng.gen_range(-0.3..0.3);
         let noise_y = rng.gen_range(-0.3..0.3);
         let measured_x = true_x + noise_x;
         let measured_y = true_y + noise_y;
-        
+
         // Kalman filter predict step
         kf.predict();
-        
+
         // Kalman filter update step
         let measurement = SVector::<f64, 2>::from([measured_x, measured_y]);
         kf.update(&measurement).expect("Update failed");
-        
+
         // Get estimated state
         let state = kf.state();
-        
+
         // Print results every 20 steps
         if step % 20 == 0 {
             println!(
                 "{:4.1} | {:8.3} | {:8.3} | {:8.3} | {:8.3} | {:8.3} | {:8.3} | {:8.3} | {:7.3}",
-                t, true_x, true_y, measured_x, measured_y,
-                state[0], state[1], state[2], state[3]
+                t, true_x, true_y, measured_x, measured_y, state[0], state[1], state[2], state[3]
             );
         }
     }
-    
+
     println!("\nFinal state covariance (diagonal elements):");
     let P = kf.covariance();
     println!("X position variance:  {:.6}", P[(0, 0)]);
     println!("Y position variance:  {:.6}", P[(1, 1)]);
     println!("X velocity variance:  {:.6}", P[(2, 2)]);
     println!("Y velocity variance:  {:.6}", P[(3, 3)]);
-    
+
     println!("\nThe filter tracked the 2D position and estimated velocities");
     println!("from noisy position measurements.");
 }

--- a/examples/sensor_fusion.rs
+++ b/examples/sensor_fusion.rs
@@ -1,5 +1,5 @@
 //! Sensor fusion example
-//! 
+//!
 //! This example demonstrates fusing data from multiple sensors with different
 //! characteristics to track a moving object. We simulate:
 //! - GPS sensor: Provides position measurements with moderate noise
@@ -26,112 +26,139 @@ fn main() {
     println!("Multi-Sensor Fusion Example (Vec-based)");
     println!("========================================");
     println!("Fusing GPS, IMU, and Radar measurements\n");
-    
+
     // Time step
     let dt = 0.1f64;
-    
+
     // State vector: [x, y, vx, vy, ax, ay] - position, velocity, acceleration
     // State transition matrix (constant acceleration model)
     let f = vec![
-        1.0, 0.0, dt,  0.0, dt*dt/2.0, 0.0,       // x
-        0.0, 1.0, 0.0, dt,  0.0,       dt*dt/2.0, // y
-        0.0, 0.0, 1.0, 0.0, dt,        0.0,       // vx
-        0.0, 0.0, 0.0, 1.0, 0.0,       dt,        // vy
-        0.0, 0.0, 0.0, 0.0, 1.0,       0.0,       // ax
-        0.0, 0.0, 0.0, 0.0, 0.0,       1.0,       // ay
+        1.0,
+        0.0,
+        dt,
+        0.0,
+        dt * dt / 2.0,
+        0.0, // x
+        0.0,
+        1.0,
+        0.0,
+        dt,
+        0.0,
+        dt * dt / 2.0, // y
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        dt,
+        0.0, // vx
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        dt, // vy
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        0.0, // ax
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0, // ay
     ];
-    
+
     // Initial state: at origin, moving with velocity (2, 1) m/s
     let x0 = vec![0.0, 0.0, 2.0, 1.0, 0.0, 0.0];
-    
+
     // Initial covariance
     let p0 = vec![
-        1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-        0.0, 1.0, 0.0, 0.0, 0.0, 0.0,
-        0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
-        0.0, 0.0, 0.0, 1.0, 0.0, 0.0,
-        0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
-        0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+        1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
     ];
-    
+
     // Process noise (uncertainty in acceleration)
     let q_acc = 0.1; // Acceleration process noise
     let mut q = vec![0.0; 36];
     // Fill process noise matrix
     q[0 * 6 + 0] = dt.powi(4) / 4.0 * q_acc; // x-x
     q[1 * 6 + 1] = dt.powi(4) / 4.0 * q_acc; // y-y
-    q[2 * 6 + 2] = dt.powi(2) * q_acc;       // vx-vx
-    q[3 * 6 + 3] = dt.powi(2) * q_acc;       // vy-vy
-    q[4 * 6 + 4] = q_acc;                    // ax-ax
-    q[5 * 6 + 5] = q_acc;                    // ay-ay
-    
+    q[2 * 6 + 2] = dt.powi(2) * q_acc; // vx-vx
+    q[3 * 6 + 3] = dt.powi(2) * q_acc; // vy-vy
+    q[4 * 6 + 4] = q_acc; // ax-ax
+    q[5 * 6 + 5] = q_acc; // ay-ay
+
     // GPS observation matrix (measures x, y position only)
     let h_gps = vec![
-        1.0, 0.0, 0.0, 0.0, 0.0, 0.0,  // x
-        0.0, 1.0, 0.0, 0.0, 0.0, 0.0,  // y
+        1.0, 0.0, 0.0, 0.0, 0.0, 0.0, // x
+        0.0, 1.0, 0.0, 0.0, 0.0, 0.0, // y
     ];
-    
+
     // GPS measurement noise (moderate position uncertainty)
     let r_gps = vec![
-        0.5, 0.0,  // GPS position noise
+        0.5, 0.0, // GPS position noise
         0.0, 0.5,
     ];
-    
+
     // Radar observation matrix (measures position and velocity)
     let h_radar = vec![
-        1.0, 0.0, 0.0, 0.0, 0.0, 0.0,  // x
-        0.0, 1.0, 0.0, 0.0, 0.0, 0.0,  // y
-        0.0, 0.0, 1.0, 0.0, 0.0, 0.0,  // vx
-        0.0, 0.0, 0.0, 1.0, 0.0, 0.0,  // vy
+        1.0, 0.0, 0.0, 0.0, 0.0, 0.0, // x
+        0.0, 1.0, 0.0, 0.0, 0.0, 0.0, // y
+        0.0, 0.0, 1.0, 0.0, 0.0, 0.0, // vx
+        0.0, 0.0, 0.0, 1.0, 0.0, 0.0, // vy
     ];
-    
+
     // Radar measurement noise (better than GPS for position, includes velocity)
     let r_radar = vec![
-        0.2, 0.0, 0.0, 0.0,  // Better position accuracy
-        0.0, 0.2, 0.0, 0.0,
-        0.0, 0.0, 0.3, 0.0,  // Velocity measurements
+        0.2, 0.0, 0.0, 0.0, // Better position accuracy
+        0.0, 0.2, 0.0, 0.0, 0.0, 0.0, 0.3, 0.0, // Velocity measurements
         0.0, 0.0, 0.0, 0.3,
     ];
-    
+
     // IMU observation matrix (measures acceleration)
     let h_imu = vec![
-        0.0, 0.0, 0.0, 0.0, 1.0, 0.0,  // ax
-        0.0, 0.0, 0.0, 0.0, 0.0, 1.0,  // ay
+        0.0, 0.0, 0.0, 0.0, 1.0, 0.0, // ax
+        0.0, 0.0, 0.0, 0.0, 0.0, 1.0, // ay
     ];
-    
+
     // IMU measurement noise
     let r_imu = vec![
-        0.05, 0.0,  // Accelerometer noise
-        0.0,  0.05,
+        0.05, 0.0, // Accelerometer noise
+        0.0, 0.05,
     ];
-    
+
     // Build Kalman filter (we'll switch observation matrices as needed)
     let mut kf = KalmanFilter::<f64>::initialize(
-        6, 2,  // 6 states, 2 measurements (will adjust for each sensor)
+        6,
+        2, // 6 states, 2 measurements (will adjust for each sensor)
         x0,
         p0,
         f,
         q,
-        h_gps.clone(),  // Start with GPS
+        h_gps.clone(), // Start with GPS
         r_gps.clone(),
-    ).expect("Failed to build Kalman filter");
-    
+    )
+    .expect("Failed to build Kalman filter");
+
     // Simulation parameters
     let mut rng = rand::thread_rng();
     let gps_noise = Normal::new(0.0, 0.5).unwrap();
     let radar_noise = Normal::new(0.0, 0.2).unwrap();
     let imu_noise = Normal::new(0.0, 0.05).unwrap();
-    
+
     // True trajectory: circular motion with changing acceleration
-    let omega = 0.2;  // Angular frequency
+    let omega = 0.2; // Angular frequency
     let radius = 10.0;
-    
+
     println!("Time | True X | True Y | GPS X  | GPS Y  | Radar X| Radar Y| Est. X | Est. Y | Est. Vx| Est. Vy");
     println!("-----|--------|--------|--------|--------|--------|--------|--------|--------|--------|--------");
-    
+
     for step in 0..100 {
         let t = step as f64 * dt;
-        
+
         // True state (circular motion)
         let true_x = radius * t.cos() * 0.1;
         let true_y = radius * t.sin() * 0.1;
@@ -139,69 +166,74 @@ fn main() {
         let true_vy = radius * omega * t.cos() * 0.1;
         let true_ax = -radius * omega * omega * t.cos() * 0.1;
         let true_ay = -radius * omega * omega * t.sin() * 0.1;
-        
+
         // Predict step
         kf.predict();
-        
+
         // Sensor measurements (alternating between sensors)
         match step % 3 {
             0 => {
                 // GPS measurement (every 3rd step)
                 let gps_x = true_x + gps_noise.sample(&mut rng);
                 let gps_y = true_y + gps_noise.sample(&mut rng);
-                
+
                 // Update observation model for GPS
                 kf.measurement_dim = 2;
                 kf.H = h_gps.clone();
                 kf.R = r_gps.clone();
-                
+
                 kf.update(&[gps_x, gps_y]).expect("GPS update failed");
-                
+
                 if step % 10 == 0 {
-                    print!("{:4.1} | {:6.2} | {:6.2} | {:6.2} | {:6.2} |", 
-                           t, true_x, true_y, gps_x, gps_y);
+                    print!(
+                        "{:4.1} | {:6.2} | {:6.2} | {:6.2} | {:6.2} |",
+                        t, true_x, true_y, gps_x, gps_y
+                    );
                 }
-            },
+            }
             1 => {
                 // Radar measurement
                 let radar_x = true_x + radar_noise.sample(&mut rng);
                 let radar_y = true_y + radar_noise.sample(&mut rng);
                 let radar_vx = true_vx + radar_noise.sample(&mut rng) * 1.5;
                 let radar_vy = true_vy + radar_noise.sample(&mut rng) * 1.5;
-                
+
                 // Update observation model for Radar
                 kf.measurement_dim = 4;
                 kf.H = h_radar.clone();
                 kf.R = r_radar.clone();
-                
-                kf.update(&[radar_x, radar_y, radar_vx, radar_vy]).expect("Radar update failed");
-                
+
+                kf.update(&[radar_x, radar_y, radar_vx, radar_vy])
+                    .expect("Radar update failed");
+
                 if step % 10 == 1 {
                     print!(" {:6.2} | {:6.2} |", radar_x, radar_y);
                 }
-            },
+            }
             _ => {
                 // IMU measurement
                 let imu_ax = true_ax + imu_noise.sample(&mut rng);
                 let imu_ay = true_ay + imu_noise.sample(&mut rng);
-                
+
                 // Update observation model for IMU
                 kf.measurement_dim = 2;
                 kf.H = h_imu.clone();
                 kf.R = r_imu.clone();
-                
+
                 kf.update(&[imu_ax, imu_ay]).expect("IMU update failed");
             }
         }
-        
+
         // Print state estimate periodically
         if step % 10 == 0 || step % 10 == 1 {
             let state = kf.state();
-            println!(" {:6.2} | {:6.2} | {:6.2} | {:6.2}",
-                    state[0], state[1], state[2], state[3]);
+            println!(
+                " {:6.2} | {:6.2} | {:6.2} | {:6.2}",
+                state[0], state[1], state[2], state[3]
+            );
         }
     }
-    
+
     println!("\nFinal state covariance (diagonal elements):");
     let p = kf.covariance();
     println!("X position variance:   {:.6}", p[0 * 6 + 0]);
@@ -210,7 +242,7 @@ fn main() {
     println!("Y velocity variance:   {:.6}", p[3 * 6 + 3]);
     println!("X acceleration variance: {:.6}", p[4 * 6 + 4]);
     println!("Y acceleration variance: {:.6}", p[5 * 6 + 5]);
-    
+
     println!("\nSensor fusion successfully combined GPS, Radar, and IMU measurements");
     println!("to provide optimal state estimation with different sensor characteristics.");
 }
@@ -220,26 +252,56 @@ fn main() {
     println!("Multi-Sensor Fusion Example (nalgebra-based)");
     println!("=============================================");
     println!("Fusing GPS, IMU, and Radar measurements\n");
-    
+
     // Time step
     let dt = 0.1;
-    
+
     // State transition matrix (constant acceleration model)
     let F = SMatrix::<f64, 6, 6>::from_row_slice(&[
-        1.0, 0.0, dt,  0.0, dt*dt/2.0, 0.0,       // x
-        0.0, 1.0, 0.0, dt,  0.0,       dt*dt/2.0, // y
-        0.0, 0.0, 1.0, 0.0, dt,        0.0,       // vx
-        0.0, 0.0, 0.0, 1.0, 0.0,       dt,        // vy
-        0.0, 0.0, 0.0, 0.0, 1.0,       0.0,       // ax
-        0.0, 0.0, 0.0, 0.0, 0.0,       1.0,       // ay
+        1.0,
+        0.0,
+        dt,
+        0.0,
+        dt * dt / 2.0,
+        0.0, // x
+        0.0,
+        1.0,
+        0.0,
+        dt,
+        0.0,
+        dt * dt / 2.0, // y
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        dt,
+        0.0, // vx
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        dt, // vy
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        0.0, // ax
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0, // ay
     ]);
-    
+
     // Initial state: at origin, moving with velocity (2, 1) m/s
     let x0 = SVector::<f64, 6>::from([0.0, 0.0, 2.0, 1.0, 0.0, 0.0]);
-    
+
     // Initial covariance
     let P0 = SMatrix::<f64, 6, 6>::identity();
-    
+
     // Process noise
     let q_acc = 0.1;
     let mut Q = SMatrix::<f64, 6, 6>::zeros();
@@ -249,60 +311,57 @@ fn main() {
     Q[(3, 3)] = dt.powi(2) * q_acc;
     Q[(4, 4)] = q_acc;
     Q[(5, 5)] = q_acc;
-    
+
     // For nalgebra version, we'll create separate filters for each sensor type
     // since we can't dynamically change dimensions
-    
+
     // GPS Kalman Filter (2 measurements)
     let H_gps = SMatrix::<f64, 2, 6>::from_row_slice(&[
-        1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-        0.0, 1.0, 0.0, 0.0, 0.0, 0.0,
+        1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0,
     ]);
-    let R_gps = SMatrix::<f64, 2, 2>::from_row_slice(&[
-        0.5, 0.0,
-        0.0, 0.5,
-    ]);
-    
+    let R_gps = SMatrix::<f64, 2, 2>::from_row_slice(&[0.5, 0.0, 0.0, 0.5]);
+
     let mut kf = StaticKalmanFilter::new(x0, P0, F, Q, H_gps, R_gps);
-    
+
     // Simulation parameters
     let mut rng = rand::thread_rng();
     let gps_noise = Normal::new(0.0, 0.5).unwrap();
-    
+
     // True trajectory
     let omega = 0.2;
     let radius = 10.0;
-    
+
     println!("Time | True X | True Y | GPS X  | GPS Y  | Est. X | Est. Y | Est. Vx| Est. Vy");
     println!("-----|--------|--------|--------|--------|--------|--------|--------|--------");
-    
+
     for step in 0..50 {
         let t = step as f64 * dt;
-        
+
         // True state
         let true_x = radius * t.cos() * 0.1;
         let true_y = radius * t.sin() * 0.1;
-        
+
         // Predict
         kf.predict();
-        
+
         // GPS measurement
         let gps_x = true_x + gps_noise.sample(&mut rng);
         let gps_y = true_y + gps_noise.sample(&mut rng);
         let measurement = SVector::<f64, 2>::from([gps_x, gps_y]);
-        
+
         // Update
         kf.update(&measurement).expect("Update failed");
-        
+
         // Print results
         if step % 10 == 0 {
             let state = kf.state();
-            println!("{:4.1} | {:6.2} | {:6.2} | {:6.2} | {:6.2} | {:6.2} | {:6.2} | {:6.2} | {:6.2}",
-                    t, true_x, true_y, gps_x, gps_y,
-                    state[0], state[1], state[2], state[3]);
+            println!(
+                "{:4.1} | {:6.2} | {:6.2} | {:6.2} | {:6.2} | {:6.2} | {:6.2} | {:6.2} | {:6.2}",
+                t, true_x, true_y, gps_x, gps_y, state[0], state[1], state[2], state[3]
+            );
         }
     }
-    
+
     println!("\nFinal state covariance (diagonal elements):");
     let P = kf.covariance();
     println!("X position variance:   {:.6}", P[(0, 0)]);
@@ -311,7 +370,11 @@ fn main() {
     println!("Y velocity variance:   {:.6}", P[(3, 3)]);
     println!("X acceleration variance: {:.6}", P[(4, 4)]);
     println!("Y acceleration variance: {:.6}", P[(5, 5)]);
-    
-    println!("\nNote: nalgebra version simplified to GPS-only due to static dimension constraints.");
-    println!("Full multi-sensor fusion would require separate filter instances or dynamic matrices.");
+
+    println!(
+        "\nNote: nalgebra version simplified to GPS-only due to static dimension constraints."
+    );
+    println!(
+        "Full multi-sensor fusion would require separate filter instances or dynamic matrices."
+    );
 }

--- a/examples/simple_1d.rs
+++ b/examples/simple_1d.rs
@@ -1,5 +1,5 @@
 //! Simple 1D Kalman filter example
-//! 
+//!
 //! This example demonstrates tracking a 1D position with noisy measurements.
 //! The system models constant velocity motion where:
 //! - State: [position, velocity]
@@ -24,39 +24,30 @@ use nalgebra::{SMatrix, SVector};
 fn main() {
     println!("Simple 1D Kalman Filter Example (Vec-based)");
     println!("============================================");
-    
+
     // Time step
     let dt = 0.1;
-    
+
     // Create state transition matrix (constant velocity model)
     // [position_new] = [1  dt] * [position_old]
     // [velocity_new]   [0  1 ]   [velocity_old]
-    let f = vec![
-        1.0, dt,
-        0.0, 1.0,
-    ];
-    
+    let f = vec![1.0, dt, 0.0, 1.0];
+
     // Initial state: position = 0, velocity = 1 m/s
     let x0 = vec![0.0, 1.0];
-    
+
     // Initial covariance (uncertainty)
-    let p0 = vec![
-        1.0, 0.0,
-        0.0, 1.0,
-    ];
-    
+    let p0 = vec![1.0, 0.0, 0.0, 1.0];
+
     // Process noise (how much the system can change randomly)
-    let q = vec![
-        0.001, 0.0,
-        0.0, 0.001,
-    ];
-    
+    let q = vec![0.001, 0.0, 0.0, 0.001];
+
     // Observation matrix (we only measure position)
     let h = vec![1.0, 0.0];
-    
+
     // Measurement noise
     let r = vec![0.1];
-    
+
     // Build the Kalman filter
     let mut kf = KalmanFilterBuilder::<f64>::new(2, 1)
         .initial_state(x0)
@@ -67,34 +58,34 @@ fn main() {
         .measurement_noise(r)
         .build()
         .expect("Failed to build Kalman filter");
-    
+
     // Simulate true system and noisy measurements
     let mut rng = rand::thread_rng();
     let true_velocity = 1.0;
     let measurement_noise_std = 0.3;
-    
+
     println!("\nTime | True Pos | Measured | Estimated | Est. Vel");
     println!("-----|----------|----------|-----------|----------");
-    
+
     for step in 0..50 {
         let t = step as f64 * dt;
         let true_position = true_velocity * t;
-        
+
         // Generate noisy measurement
         let noise = rng.gen_range(-measurement_noise_std..measurement_noise_std);
         let measured_position = true_position + noise;
-        
+
         // Kalman filter predict step
         kf.predict();
-        
+
         // Kalman filter update step
         kf.update(&[measured_position]).expect("Update failed");
-        
+
         // Get estimated state
         let state = kf.state();
         let estimated_position = state[0];
         let estimated_velocity = state[1];
-        
+
         // Print results every 10 steps
         if step % 10 == 0 {
             println!(
@@ -103,12 +94,12 @@ fn main() {
             );
         }
     }
-    
+
     println!("\nFinal state covariance:");
     let p = kf.covariance();
     println!("Position variance: {:.6}", p[0]);
     println!("Velocity variance: {:.6}", p[3]);
-    
+
     println!("\nThe Kalman filter successfully tracked the position and");
     println!("estimated the velocity from noisy position measurements.");
 }
@@ -117,70 +108,59 @@ fn main() {
 fn main() {
     println!("Simple 1D Kalman Filter Example (nalgebra-based)");
     println!("=================================================");
-    
+
     // Time step
     let dt = 0.1;
-    
+
     // Create state transition matrix (constant velocity model)
-    let F = SMatrix::<f64, 2, 2>::from_row_slice(&[
-        1.0, dt,
-        0.0, 1.0,
-    ]);
-    
+    let F = SMatrix::<f64, 2, 2>::from_row_slice(&[1.0, dt, 0.0, 1.0]);
+
     // Initial state: position = 0, velocity = 1 m/s
     let x0 = SVector::<f64, 2>::from([0.0, 1.0]);
-    
+
     // Initial covariance (uncertainty)
-    let P0 = SMatrix::<f64, 2, 2>::from_row_slice(&[
-        1.0, 0.0,
-        0.0, 1.0,
-    ]);
-    
+    let P0 = SMatrix::<f64, 2, 2>::from_row_slice(&[1.0, 0.0, 0.0, 1.0]);
+
     // Process noise (how much the system can change randomly)
-    let Q = SMatrix::<f64, 2, 2>::from_row_slice(&[
-        0.001, 0.0,
-        0.0, 0.001,
-    ]);
-    
+    let Q = SMatrix::<f64, 2, 2>::from_row_slice(&[0.001, 0.0, 0.0, 0.001]);
+
     // Observation matrix (we only measure position)
-    let H = SMatrix::<f64, 1, 2>::from_row_slice(&[
-        1.0, 0.0,
-    ]);
-    
+    let H = SMatrix::<f64, 1, 2>::from_row_slice(&[1.0, 0.0]);
+
     // Measurement noise
     let R = SMatrix::<f64, 1, 1>::from_row_slice(&[0.1]);
-    
+
     // Create the Kalman filter
     let mut kf = StaticKalmanFilter::new(x0, P0, F, Q, H, R);
-    
+
     // Simulate true system and noisy measurements
     let mut rng = rand::thread_rng();
     let true_velocity = 1.0;
     let measurement_noise_std = 0.3;
-    
+
     println!("\nTime | True Pos | Measured | Estimated | Est. Vel");
     println!("-----|----------|----------|-----------|----------");
-    
+
     for step in 0..50 {
         let t = step as f64 * dt;
         let true_position = true_velocity * t;
-        
+
         // Generate noisy measurement
         let noise = rng.gen_range(-measurement_noise_std..measurement_noise_std);
         let measured_position = true_position + noise;
-        
+
         // Kalman filter predict step
         kf.predict();
-        
+
         // Kalman filter update step
         let measurement = SVector::<f64, 1>::from([measured_position]);
         kf.update(&measurement).expect("Update failed");
-        
+
         // Get estimated state
         let state = kf.state();
         let estimated_position = state[0];
         let estimated_velocity = state[1];
-        
+
         // Print results every 10 steps
         if step % 10 == 0 {
             println!(
@@ -189,12 +169,12 @@ fn main() {
             );
         }
     }
-    
+
     println!("\nFinal state covariance:");
     let P = kf.covariance();
     println!("Position variance: {:.6}", P[(0, 0)]);
     println!("Velocity variance: {:.6}", P[(1, 1)]);
-    
+
     println!("\nThe Kalman filter successfully tracked the position and");
     println!("estimated the velocity from noisy position measurements.");
 }

--- a/examples/ukf_nonlinear_tracking.rs
+++ b/examples/ukf_nonlinear_tracking.rs
@@ -5,7 +5,7 @@
 //! requiring Jacobian calculations.
 #![allow(unused, non_snake_case)] // DO NOT CHANGE
 
-use kalman_filters::{UnscentedKalmanFilter, UKFParameters, NonlinearSystem};
+use kalman_filters::{NonlinearSystem, UKFParameters, UnscentedKalmanFilter};
 
 /// Nonlinear target dynamics with coordinated turn model
 struct CoordinatedTurnModel {
@@ -15,23 +15,18 @@ struct CoordinatedTurnModel {
 
 impl NonlinearSystem<f64> for CoordinatedTurnModel {
     fn state_transition(&self, state: &[f64], _control: Option<&[f64]>, dt: f64) -> Vec<f64> {
-        let x = state[0];      // x position
-        let y = state[1];      // y position
-        let vx = state[2];     // x velocity
-        let vy = state[3];     // y velocity
-        
+        let x = state[0]; // x position
+        let y = state[1]; // y position
+        let vx = state[2]; // x velocity
+        let vy = state[3]; // y velocity
+
         // Coordinated turn model
         let sin_wt = (self.omega * dt).sin();
         let cos_wt = (self.omega * dt).cos();
-        
+
         if self.omega.abs() < 1e-6 {
             // Linear motion when turn rate is near zero
-            vec![
-                x + vx * dt,
-                y + vy * dt,
-                vx,
-                vy,
-            ]
+            vec![x + vx * dt, y + vy * dt, vx, vy]
         } else {
             // Nonlinear coordinated turn
             vec![
@@ -42,57 +37,55 @@ impl NonlinearSystem<f64> for CoordinatedTurnModel {
             ]
         }
     }
-    
+
     fn measurement(&self, state: &[f64]) -> Vec<f64> {
         // Radar measurement: range and bearing
         let x = state[0];
         let y = state[1];
-        
+
         vec![
-            (x * x + y * y).sqrt(),  // Range
-            y.atan2(x),              // Bearing
+            (x * x + y * y).sqrt(), // Range
+            y.atan2(x),             // Bearing
         ]
     }
-    
+
     fn state_jacobian(&self, _state: &[f64], _control: Option<&[f64]>, _dt: f64) -> Vec<f64> {
         unreachable!("UKF doesn't need Jacobians")
     }
-    
+
     fn measurement_jacobian(&self, _state: &[f64]) -> Vec<f64> {
         unreachable!("UKF doesn't need Jacobians")
     }
-    
-    fn state_dim(&self) -> usize { 4 }
-    fn measurement_dim(&self) -> usize { 2 }
+
+    fn state_dim(&self) -> usize {
+        4
+    }
+    fn measurement_dim(&self) -> usize {
+        2
+    }
 }
 
 fn main() {
     println!("=== UKF Nonlinear Target Tracking Example ===\n");
-    
+
     // Create coordinated turn model
     let system = CoordinatedTurnModel { omega: 0.1 }; // 0.1 rad/s turn rate
-    
+
     // Initial state: [x, y, vx, vy]
     let initial_state = vec![100.0, 50.0, 10.0, 5.0];
     let initial_covariance = vec![
-        10.0, 0.0, 0.0, 0.0,
-        0.0, 10.0, 0.0, 0.0,
-        0.0, 0.0, 1.0, 0.0,
-        0.0, 0.0, 0.0, 1.0,
+        10.0, 0.0, 0.0, 0.0, 0.0, 10.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
     ];
-    
+
     // Process and measurement noise
     let process_noise = vec![
-        0.1, 0.0, 0.0, 0.0,
-        0.0, 0.1, 0.0, 0.0,
-        0.0, 0.0, 0.01, 0.0,
-        0.0, 0.0, 0.0, 0.01,
+        0.1, 0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0, 0.0, 0.0, 0.01,
     ];
     let measurement_noise = vec![
-        1.0, 0.0,  // Range noise
+        1.0, 0.0, // Range noise
         0.0, 0.01, // Bearing noise (radians)
     ];
-    
+
     // Create UKF
     let mut ukf = UnscentedKalmanFilter::new(
         system,
@@ -101,51 +94,58 @@ fn main() {
         process_noise,
         measurement_noise,
         1.0, // dt = 1 second
-    ).unwrap();
-    
+    )
+    .unwrap();
+
     // Set UKF parameters for better performance
     let mut params = UKFParameters::default();
     params.alpha = 1e-3;
     params.beta = 2.0;
     params.kappa = 0.0;
     ukf.set_parameters(params);
-    
-    println!("Initial state: x={:.1}, y={:.1}, vx={:.1}, vy={:.1}",
-        ukf.state()[0], ukf.state()[1], ukf.state()[2], ukf.state()[3]);
-    
+
+    println!(
+        "Initial state: x={:.1}, y={:.1}, vx={:.1}, vy={:.1}",
+        ukf.state()[0],
+        ukf.state()[1],
+        ukf.state()[2],
+        ukf.state()[3]
+    );
+
     // Simulate tracking for 10 time steps
     println!("\nTracking target with coordinated turn model:");
     println!("Time | Range | Bearing | Est. X | Est. Y | Est. Vx | Est. Vy");
     println!("-----|-------|---------|--------|--------|---------|--------");
-    
+
     for t in 1..=10 {
         // Predict
         ukf.predict().unwrap();
-        
+
         // Generate simulated measurement (with noise)
         let true_state = ukf.state();
         let true_range = (true_state[0].powi(2) + true_state[1].powi(2)).sqrt();
         let true_bearing = true_state[1].atan2(true_state[0]);
-        
+
         // Add measurement noise
         let measured_range = true_range + 0.5 * (t as f64).sin();
         let measured_bearing = true_bearing + 0.01 * (t as f64 * 0.7).cos();
-        
+
         // Update with measurement
         ukf.update(&[measured_range, measured_bearing]).unwrap();
-        
+
         // Print results
         let state = ukf.state();
-        println!("{:4} | {:5.1} | {:7.3} | {:6.1} | {:6.1} | {:7.2} | {:6.2}",
-            t, measured_range, measured_bearing,
-            state[0], state[1], state[2], state[3]);
+        println!(
+            "{:4} | {:5.1} | {:7.3} | {:6.1} | {:6.1} | {:7.2} | {:6.2}",
+            t, measured_range, measured_bearing, state[0], state[1], state[2], state[3]
+        );
     }
-    
+
     // Print final covariance
     println!("\nFinal position uncertainty (std dev):");
     let cov = ukf.covariance();
     println!("  σ_x = {:.2} m", cov[0].sqrt());
     println!("  σ_y = {:.2} m", cov[5].sqrt());
-    
+
     println!("\n✓ UKF successfully tracked nonlinear target motion");
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -134,23 +134,17 @@ where
         let m = self.measurement_dim;
 
         if !is_symmetric(&initial_covariance, n) {
-            error!(
-                "KalmanFilterBuilder: initial_covariance is not symmetric (size={n}x{n})"
-            );
+            error!("KalmanFilterBuilder: initial_covariance is not symmetric (size={n}x{n})");
             return Err(KalmanError::InvalidCovariance);
         }
         debug!("Initial covariance matrix validated as symmetric");
         if !is_symmetric(&process_noise, n) {
-            error!(
-                "KalmanFilterBuilder: process_noise is not symmetric (size={n}x{n})"
-            );
+            error!("KalmanFilterBuilder: process_noise is not symmetric (size={n}x{n})");
             return Err(KalmanError::InvalidNoiseCovariance);
         }
         debug!("Process noise matrix validated as symmetric");
         if !is_symmetric(&measurement_noise, m) {
-            error!(
-                "KalmanFilterBuilder: measurement_noise is not symmetric (size={m}x{m})"
-            );
+            error!("KalmanFilterBuilder: measurement_noise is not symmetric (size={m}x{m})");
             return Err(KalmanError::InvalidNoiseCovariance);
         }
         debug!("Measurement noise matrix validated as symmetric");

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -95,7 +95,7 @@ where
 
     /// Build the Kalman filter
     pub fn build(self) -> KalmanResult<KalmanFilter<T>> {
-        info!(
+        debug!(
             "Building Kalman filter: state_dim={}, measurement_dim={}",
             self.state_dim, self.measurement_dim
         );

--- a/src/builders/ensemble.rs
+++ b/src/builders/ensemble.rs
@@ -133,7 +133,7 @@ where
         let n = self.system.state_dim();
         let m = self.system.measurement_dim();
 
-        info!(
+        debug!(
             "Building Ensemble Kalman Filter: state_dim={}, measurement_dim={}",
             n, m
         );

--- a/src/builders/ensemble.rs
+++ b/src/builders/ensemble.rs
@@ -10,7 +10,7 @@ use log::{debug, error, info};
 /// ```no_run
 /// use kalman_filters::builders::EnsembleKalmanFilterBuilder;
 /// use kalman_filters::NonlinearSystem;
-/// 
+///
 /// # struct MySystem;
 /// # impl NonlinearSystem<f64> for MySystem {
 /// #     fn state_dim(&self) -> usize { 2 }
@@ -132,7 +132,7 @@ where
     pub fn build(self) -> KalmanResult<EnsembleKalmanFilter<T, S>> {
         let n = self.system.state_dim();
         let m = self.system.measurement_dim();
-        
+
         info!(
             "Building Ensemble Kalman Filter: state_dim={}, measurement_dim={}",
             n, m

--- a/src/builders/extended.rs
+++ b/src/builders/extended.rs
@@ -117,7 +117,7 @@ where
         let n = self.system.state_dim();
         let m = self.system.measurement_dim();
 
-        info!(
+        debug!(
             "Building Extended Kalman Filter: state_dim={}, measurement_dim={}",
             n, m
         );

--- a/src/builders/extended.rs
+++ b/src/builders/extended.rs
@@ -1,8 +1,8 @@
 //! Builder for Extended Kalman Filter
 
 use crate::extended::ExtendedKalmanFilter;
-use crate::types::{JacobianStrategy, KalmanError, KalmanResult, KalmanScalar, NonlinearSystem};
 use crate::logging::{check_numerical_stability, log_filter_dimensions};
+use crate::types::{JacobianStrategy, KalmanError, KalmanResult, KalmanScalar, NonlinearSystem};
 use log::{debug, error, info};
 
 /// Builder for constructing Extended Kalman Filters
@@ -11,7 +11,7 @@ use log::{debug, error, info};
 /// ```no_run
 /// use kalman_filters::builders::ExtendedKalmanFilterBuilder;
 /// use kalman_filters::NonlinearSystem;
-/// 
+///
 /// # struct MySystem;
 /// # impl NonlinearSystem<f64> for MySystem {
 /// #     fn state_dim(&self) -> usize { 2 }
@@ -116,7 +116,7 @@ where
     pub fn build(self) -> KalmanResult<ExtendedKalmanFilter<T, S>> {
         let n = self.system.state_dim();
         let m = self.system.measurement_dim();
-        
+
         info!(
             "Building Extended Kalman Filter: state_dim={}, measurement_dim={}",
             n, m

--- a/src/builders/information.rs
+++ b/src/builders/information.rs
@@ -9,7 +9,7 @@ use log::{debug, error, info};
 /// # Example
 /// ```no_run
 /// use kalman_filters::builders::InformationFilterBuilder;
-/// 
+///
 /// let if_filter = InformationFilterBuilder::new(2, 1)
 ///     .initial_information_matrix(vec![1.0, 0.0, 0.0, 1.0])
 ///     .initial_information_vector(vec![0.0, 0.0])
@@ -57,7 +57,7 @@ impl<T: KalmanScalar> InformationFilterBuilder<T> {
         measurement_dim: usize,
     ) -> KalmanResult<Self> {
         let state_dim = initial_state.len();
-        
+
         debug!(
             "Creating InformationFilterBuilder from state/covariance: state_dim={}, measurement_dim={}",
             state_dim, measurement_dim
@@ -66,7 +66,7 @@ impl<T: KalmanScalar> InformationFilterBuilder<T> {
         // Convert to information form using matrix inversion
         use crate::filter::KalmanFilter;
         let Y = KalmanFilter::<T>::invert_matrix(&initial_covariance, state_dim)?;
-        
+
         // y = Y * x
         let mut y = vec![T::zero(); state_dim];
         for i in 0..state_dim {

--- a/src/builders/information.rs
+++ b/src/builders/information.rs
@@ -132,7 +132,7 @@ impl<T: KalmanScalar> InformationFilterBuilder<T> {
 
     /// Build the Information Filter
     pub fn build(self) -> KalmanResult<InformationFilter<T>> {
-        info!(
+        debug!(
             "Building Information Filter: state_dim={}, measurement_dim={}",
             self.state_dim, self.measurement_dim
         );

--- a/src/builders/mod.rs
+++ b/src/builders/mod.rs
@@ -3,16 +3,16 @@
 //! This module provides builder patterns for all filter types, enabling
 //! type-safe construction with validation deferred to the build phase.
 
-mod extended;
-mod unscented;
-mod scented;
 mod ensemble;
+mod extended;
 mod information;
 mod particle;
+mod scented;
+mod unscented;
 
-pub use extended::ExtendedKalmanFilterBuilder;
-pub use unscented::UnscentedKalmanFilterBuilder;
-pub use scented::CubatureKalmanFilterBuilder;
 pub use ensemble::EnsembleKalmanFilterBuilder;
+pub use extended::ExtendedKalmanFilterBuilder;
 pub use information::InformationFilterBuilder;
 pub use particle::ParticleFilterBuilder;
+pub use scented::CubatureKalmanFilterBuilder;
+pub use unscented::UnscentedKalmanFilterBuilder;

--- a/src/builders/particle.rs
+++ b/src/builders/particle.rs
@@ -9,7 +9,7 @@ use log::{debug, error, info};
 /// # Example
 /// ```no_run
 /// use kalman_filters::builders::ParticleFilterBuilder;
-/// 
+///
 /// let pf = ParticleFilterBuilder::new(2, 100)
 ///     .initial_mean(vec![0.0, 0.0])
 ///     .initial_std(vec![1.0, 1.0])
@@ -139,7 +139,7 @@ impl<T: KalmanScalar> ParticleFilterBuilder<T> {
 
         // Set optional parameters
         pf.set_resampling_strategy(self.resampling_strategy);
-        
+
         if let Some(threshold) = self.ess_threshold {
             pf.ess_threshold = threshold;
         }

--- a/src/builders/particle.rs
+++ b/src/builders/particle.rs
@@ -95,7 +95,7 @@ impl<T: KalmanScalar> ParticleFilterBuilder<T> {
 
     /// Build the Particle Filter
     pub fn build(self) -> KalmanResult<ParticleFilter<T>> {
-        info!(
+        debug!(
             "Building Particle Filter: state_dim={}, num_particles={}",
             self.state_dim, self.num_particles
         );

--- a/src/builders/scented.rs
+++ b/src/builders/scented.rs
@@ -108,7 +108,7 @@ where
         let n = self.system.state_dim();
         let m = self.system.measurement_dim();
 
-        info!(
+        debug!(
             "Building Cubature Kalman Filter: state_dim={}, measurement_dim={}",
             n, m
         );

--- a/src/builders/scented.rs
+++ b/src/builders/scented.rs
@@ -10,7 +10,7 @@ use log::{debug, error, info};
 /// ```no_run
 /// use kalman_filters::builders::CubatureKalmanFilterBuilder;
 /// use kalman_filters::NonlinearSystem;
-/// 
+///
 /// # struct MySystem;
 /// # impl NonlinearSystem<f64> for MySystem {
 /// #     fn state_dim(&self) -> usize { 2 }
@@ -107,7 +107,7 @@ where
     pub fn build(self) -> KalmanResult<CubatureKalmanFilter<T, S>> {
         let n = self.system.state_dim();
         let m = self.system.measurement_dim();
-        
+
         info!(
             "Building Cubature Kalman Filter: state_dim={}, measurement_dim={}",
             n, m

--- a/src/builders/unscented.rs
+++ b/src/builders/unscented.rs
@@ -134,7 +134,7 @@ where
         let n = self.system.state_dim();
         let m = self.system.measurement_dim();
 
-        info!(
+        debug!(
             "Building Unscented Kalman Filter: state_dim={}, measurement_dim={}",
             n, m
         );

--- a/src/builders/unscented.rs
+++ b/src/builders/unscented.rs
@@ -1,7 +1,7 @@
 //! Builder for Unscented Kalman Filter
 
-use crate::unscented::{UnscentedKalmanFilter, UKFParameters};
 use crate::types::{KalmanError, KalmanResult, KalmanScalar, NonlinearSystem};
+use crate::unscented::{UKFParameters, UnscentedKalmanFilter};
 use log::{debug, error, info};
 
 /// Builder for constructing Unscented Kalman Filters
@@ -10,7 +10,7 @@ use log::{debug, error, info};
 /// ```no_run
 /// use kalman_filters::builders::UnscentedKalmanFilterBuilder;
 /// use kalman_filters::NonlinearSystem;
-/// 
+///
 /// # struct MySystem;
 /// # impl NonlinearSystem<f64> for MySystem {
 /// #     fn state_dim(&self) -> usize { 2 }
@@ -133,7 +133,7 @@ where
     pub fn build(self) -> KalmanResult<UnscentedKalmanFilter<T, S>> {
         let n = self.system.state_dim();
         let m = self.system.measurement_dim();
-        
+
         info!(
             "Building Unscented Kalman Filter: state_dim={}, measurement_dim={}",
             n, m

--- a/src/ensemble/filter.rs
+++ b/src/ensemble/filter.rs
@@ -153,7 +153,7 @@ where
         let m = system.measurement_dim();
 
         log_filter_dimensions(n, m, None);
-        info!(
+        debug!(
             "Ensemble Kalman Filter: Initializing with {} ensemble members",
             ensemble_size
         );

--- a/src/ensemble/filter.rs
+++ b/src/ensemble/filter.rs
@@ -31,14 +31,14 @@ pub struct EnsembleStatistics<T: KalmanScalar> {
 /// The EnKF is particularly suited for systems with dimensions >> 1000 where
 /// storing and manipulating full covariance matrices becomes prohibitive.
 /// It uses Monte Carlo sampling to represent uncertainty.
-/// 
+///
 /// # Example
-/// 
+///
 /// ```no_run
 /// use kalman_filters::{EnsembleKalmanFilterBuilder, NonlinearSystem};
-/// 
+///
 /// struct SimpleSystem;
-/// 
+///
 /// impl NonlinearSystem<f64> for SimpleSystem {
 ///     fn state_transition(&self, state: &[f64], _control: Option<&[f64]>, dt: f64) -> Vec<f64> {
 ///         vec![state[0] + dt * state[1], state[1]]
@@ -59,7 +59,7 @@ pub struct EnsembleStatistics<T: KalmanScalar> {
 ///     fn state_dim(&self) -> usize { 2 }
 ///     fn measurement_dim(&self) -> usize { 1 }
 /// }
-/// 
+///
 /// let mut enkf = EnsembleKalmanFilterBuilder::new(SimpleSystem)
 ///     .initial_mean(vec![0.0, 0.0])
 ///     .initial_spread(vec![1.0, 0.1])
@@ -108,7 +108,10 @@ where
     S: NonlinearSystem<T>,
 {
     /// Create a new Ensemble Kalman Filter
-    #[deprecated(since = "1.0.0-alpha0", note = "Use EnsembleKalmanFilterBuilder instead")]
+    #[deprecated(
+        since = "1.0.0-alpha0",
+        note = "Use EnsembleKalmanFilterBuilder instead"
+    )]
     pub fn new(
         system: S,
         initial_mean: Vec<T>,

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -138,7 +138,7 @@ where
         let m = system.measurement_dim();
 
         log_filter_dimensions(n, m, None);
-        info!("Initializing Extended Kalman Filter");
+        debug!("Initializing Extended Kalman Filter");
 
         // Validate dimensions
         if initial_state.len() != n {

--- a/src/extended.rs
+++ b/src/extended.rs
@@ -628,8 +628,12 @@ mod tests {
             fn measurement_jacobian(&self, _: &[f64]) -> Vec<f64> {
                 vec![1.0, 0.0]
             }
-            fn state_dim(&self) -> usize { 2 }
-            fn measurement_dim(&self) -> usize { 1 }
+            fn state_dim(&self) -> usize {
+                2
+            }
+            fn measurement_dim(&self) -> usize {
+                1
+            }
         }
 
         let system = BadSystem;
@@ -641,7 +645,7 @@ mod tests {
             vec![0.1],
             0.01,
         );
-        
+
         // Should detect dimension mismatch
         assert!(result.is_ok()); // Creation is ok, error happens on predict
     }
@@ -663,8 +667,12 @@ mod tests {
             fn measurement_jacobian(&self, _: &[f64]) -> Vec<f64> {
                 vec![1.0, 0.0]
             }
-            fn state_dim(&self) -> usize { 2 }
-            fn measurement_dim(&self) -> usize { 1 }
+            fn state_dim(&self) -> usize {
+                2
+            }
+            fn measurement_dim(&self) -> usize {
+                1
+            }
         }
 
         let system = LinearSystem;
@@ -675,7 +683,8 @@ mod tests {
             vec![0.01, 0.0, 0.0, 0.01],
             vec![0.1],
             0.1,
-        ).unwrap();
+        )
+        .unwrap();
 
         // True position after 10 steps: 0 + 1*0.1*10 = 1.0
         for i in 0..10 {
@@ -698,7 +707,8 @@ mod tests {
             vec![0.001, 0.0, 0.0, 0.001],
             vec![0.01],
             0.01,
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(ekf.state().len(), 2);
         assert_eq!(ekf.covariance().len(), 4);
@@ -709,7 +719,12 @@ mod tests {
     fn test_ekf_control_input() {
         struct ControlledSystem;
         impl NonlinearSystem<f64> for ControlledSystem {
-            fn state_transition(&self, state: &[f64], control: Option<&[f64]>, dt: f64) -> Vec<f64> {
+            fn state_transition(
+                &self,
+                state: &[f64],
+                control: Option<&[f64]>,
+                dt: f64,
+            ) -> Vec<f64> {
                 let u = control.map(|c| c[0]).unwrap_or(0.0);
                 vec![state[0] + state[1] * dt, state[1] + u * dt]
             }
@@ -722,8 +737,12 @@ mod tests {
             fn measurement_jacobian(&self, _: &[f64]) -> Vec<f64> {
                 vec![1.0, 0.0]
             }
-            fn state_dim(&self) -> usize { 2 }
-            fn measurement_dim(&self) -> usize { 1 }
+            fn state_dim(&self) -> usize {
+                2
+            }
+            fn measurement_dim(&self) -> usize {
+                1
+            }
         }
 
         let system = ControlledSystem;
@@ -734,7 +753,8 @@ mod tests {
             vec![0.01, 0.0, 0.0, 0.01],
             vec![0.1],
             0.1,
-        ).unwrap();
+        )
+        .unwrap();
 
         // Apply control to accelerate
         ekf.set_control(vec![1.0]);
@@ -747,10 +767,10 @@ mod tests {
         let system = PendulumSystem { g: 9.81, l: 1.0 };
         let state = vec![0.1, 0.0];
         let dt = 0.01;
-        
+
         // Analytical Jacobian
         let analytical = system.state_jacobian(&state, None, dt);
-        
+
         // Numerical Jacobian
         let ekf = ExtendedKalmanFilter::new(
             system,
@@ -759,11 +779,12 @@ mod tests {
             vec![0.01, 0.0, 0.0, 0.01],
             vec![0.1],
             dt,
-        ).unwrap();
-        
+        )
+        .unwrap();
+
         // Get numerical jacobian using the internal method
         let numerical = ekf.compute_numerical_jacobian_state(1e-6);
-        
+
         // Compare analytical and numerical
         for i in 0..4 {
             assert!((analytical[i] - numerical[i]).abs() < 1e-4);

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -498,10 +498,10 @@ where
 }
 
 /// Optimized Kalman filter implementation using static matrices from nalgebra
-/// 
+///
 /// This provides compile-time dimension checking and better performance
 /// for filters with known dimensions at compile time.
-/// 
+///
 /// Type parameters:
 /// - `T`: Scalar type (f32 or f64)
 /// - `M`: Measurement dimension
@@ -720,7 +720,7 @@ mod tests {
             2,
             1,
             vec![0.0, 0.0], // state
-            vec![1.0],       // P wrong size (should be 2x2)
+            vec![1.0],      // P wrong size (should be 2x2)
             vec![1.0, 0.0, 0.0, 1.0],
             vec![0.1, 0.0, 0.0, 0.1],
             vec![1.0, 0.0],
@@ -744,7 +744,7 @@ mod tests {
     #[test]
     fn test_predict_update_cycle() {
         let mut kf = KalmanFilter::<f64>::new(2, 1);
-        
+
         // Initialize with identity matrices
         kf.x = vec![0.0, 0.0];
         kf.P = vec![1.0, 0.0, 0.0, 1.0];
@@ -752,15 +752,15 @@ mod tests {
         kf.Q = vec![0.01, 0.0, 0.0, 0.01];
         kf.H = vec![1.0, 0.0]; // Observe first state
         kf.R = vec![0.1];
-        
+
         // Store initial covariance trace
         let initial_trace = kf.P[0] + kf.P[3];
-        
+
         // Predict increases uncertainty
         kf.predict();
         let predict_trace = kf.P[0] + kf.P[3];
         assert!(predict_trace > initial_trace);
-        
+
         // Update reduces uncertainty
         let result = kf.update(&vec![0.5]);
         assert!(result.is_ok());
@@ -775,7 +775,7 @@ mod tests {
         let a = vec![1.0, 2.0, 3.0, 4.0];
         let b = vec![5.0, 6.0, 7.0, 8.0];
         let mut result = vec![0.0; 4];
-        
+
         // Manual matrix multiply
         for i in 0..2 {
             for j in 0..2 {
@@ -784,7 +784,7 @@ mod tests {
                 }
             }
         }
-        
+
         // Expected: [1*5+2*7, 1*6+2*8, 3*5+4*7, 3*6+4*8]
         assert_eq!(result, vec![19.0, 22.0, 43.0, 50.0]);
     }
@@ -793,14 +793,14 @@ mod tests {
     fn test_matrix_transpose() {
         let matrix = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]; // 2x3 matrix
         let mut result = vec![0.0; 6];
-        
+
         // Manual transpose
         for i in 0..2 {
             for j in 0..3 {
                 result[j * 2 + i] = matrix[i * 3 + j];
             }
         }
-        
+
         // Expected: 3x2 matrix
         assert_eq!(result, vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
     }
@@ -831,15 +831,15 @@ mod tests {
         kf.Q = vec![0.001];
         kf.H = vec![1.0];
         kf.R = vec![1.0];
-        
+
         let true_value = 5.0;
-        
+
         // Feed repeated measurements
         for _ in 0..50 {
             kf.predict();
             kf.update(&vec![true_value]).unwrap();
         }
-        
+
         // Should converge close to true value
         assert!((kf.x[0] - true_value).abs() < 0.1);
         // Uncertainty should be low
@@ -858,7 +858,7 @@ mod tests {
     #[test]
     fn test_control_input() {
         let mut kf = KalmanFilter::<f64>::new(2, 1);
-        
+
         // Initialize system
         kf.x = vec![0.0, 0.0];
         kf.P = vec![1.0, 0.0, 0.0, 1.0];
@@ -866,15 +866,15 @@ mod tests {
         kf.Q = vec![0.01, 0.0, 0.0, 0.01];
         kf.H = vec![1.0, 0.0];
         kf.R = vec![0.1];
-        
+
         // Simple control input simulation
         let control = vec![0.0, 2.0]; // Control affects velocity
-        
+
         // Apply control manually
         for i in 0..2 {
             kf.x[i] += control[i];
         }
-        
+
         // Velocity should have increased
         assert!((kf.x[1] - 2.0).abs() < 1e-10);
     }
@@ -889,12 +889,12 @@ mod tests {
         kf.Q = vec![0.1];
         kf.H = vec![1.0];
         kf.R = vec![1.0];
-        
+
         kf.predict();
         let p_before = kf.P[0];
-        
+
         kf.update(&vec![1.0]).unwrap();
-        
+
         // Covariance should remain positive
         assert!(kf.P[0] > 0.0);
         // Covariance should decrease after update

--- a/src/information/consensus.rs
+++ b/src/information/consensus.rs
@@ -39,7 +39,7 @@ pub struct AverageConsensus<T: KalmanScalar> {
 impl<T: KalmanScalar> AverageConsensus<T> {
     /// Create new average consensus with Metropolis weights
     pub fn new_metropolis(topology: &HashMap<usize, Vec<usize>>, state_dim: usize) -> Self {
-        info!(
+        debug!(
             "Creating AverageConsensus with Metropolis weights: {} nodes, state_dim={}",
             topology.len(),
             state_dim
@@ -236,7 +236,7 @@ pub struct WeightedConsensus<T: KalmanScalar> {
 impl<T: KalmanScalar> WeightedConsensus<T> {
     /// Create new weighted consensus
     pub fn new(state_dim: usize) -> Self {
-        info!("Creating WeightedConsensus: state_dim={}", state_dim);
+        debug!("Creating WeightedConsensus: state_dim={}", state_dim);
         Self {
             confidence_weights: HashMap::new(),
             prev_states: HashMap::new(),
@@ -369,7 +369,7 @@ pub struct MaxConsensus<T: KalmanScalar> {
 impl<T: KalmanScalar> MaxConsensus<T> {
     /// Create a new max-consensus algorithm instance
     pub fn new(state_dim: usize) -> Self {
-        info!("Creating MaxConsensus: state_dim={}", state_dim);
+        debug!("Creating MaxConsensus: state_dim={}", state_dim);
         Self {
             max_node: None,
             max_state: None,

--- a/src/information/conversion.rs
+++ b/src/information/conversion.rs
@@ -93,7 +93,7 @@ impl<T: KalmanScalar> HybridFilter<T> {
         R: Vec<T>,
         sparsity_threshold: f64,
     ) -> KalmanResult<Self> {
-        info!(
+        debug!(
             "Creating HybridFilter: state_dim={}, measurement_dim={}, sparsity_threshold={:.2}",
             state_dim, measurement_dim, sparsity_threshold
         );
@@ -129,7 +129,7 @@ impl<T: KalmanScalar> HybridFilter<T> {
             self.inf = Some(kalman_to_information(kf)?);
             self.kf = None;
             self.current_form = FilterForm::Information;
-            info!("HybridFilter: successfully switched to information form");
+            debug!("HybridFilter: successfully switched to information form");
         }
 
         Ok(())
@@ -148,7 +148,7 @@ impl<T: KalmanScalar> HybridFilter<T> {
             self.kf = Some(information_to_kalman(inf)?);
             self.inf = None;
             self.current_form = FilterForm::Covariance;
-            info!("HybridFilter: successfully switched to covariance form");
+            debug!("HybridFilter: successfully switched to covariance form");
         }
 
         Ok(())

--- a/src/information/filter.rs
+++ b/src/information/filter.rs
@@ -27,7 +27,7 @@ impl<T: KalmanScalar> InformationState<T> {
     /// Create new information state
     pub fn new(dim: usize) -> Self {
         log_filter_dimensions(dim, 0, None);
-        info!(
+        debug!(
             "Information Filter: Initializing information state with dimension {}",
             dim
         );
@@ -204,7 +204,7 @@ impl<T: KalmanScalar> InformationFilter<T> {
         R: Vec<T>,
     ) -> KalmanResult<Self> {
         log_filter_dimensions(state_dim, measurement_dim, None);
-        info!(
+        debug!(
             "Information Filter: Initializing filter with state_dim={}, measurement_dim={}",
             state_dim, measurement_dim
         );
@@ -417,7 +417,7 @@ impl<T: KalmanScalar> InformationFilter<T> {
         // measurements: Vec<(z_i, H_i, R_i)>
         let n = self.state_dim;
 
-        info!(
+        debug!(
             "Information Filter: Fusing {} measurements simultaneously",
             measurements.len()
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,12 @@
 //! # Kalman Filter Implementation
-//! 
+//!
 //! This crate provides a Kalman filter implementation for state estimation
 //! in linear dynamic systems. The Kalman filter is an optimal recursive
 //! estimator that combines predictions from a system model with measurements
 //! to estimate the true state of a system.
 //!
 //! ## Features
-//! 
+//!
 //! - Linear Kalman filter with predict and update steps
 //! - Dynamic dimension support without external dependencies
 //! - Support for both f32 and f64 precision
@@ -78,10 +78,10 @@ pub use filter::KalmanFilter;
 pub use filter::KalmanFilter as ModernKalmanFilter;
 
 pub use information::filter::InformationFilter;
-pub use particle::{ParticleFilter, Particle, ResamplingStrategy};
+pub use particle::{Particle, ParticleFilter, ResamplingStrategy};
 pub use scented::CubatureKalmanFilter;
 pub use types::{JacobianStrategy, KalmanResult, KalmanScalar, NonlinearSystem};
-pub use unscented::{UnscentedKalmanFilter, UKFParameters};
+pub use unscented::{UKFParameters, UnscentedKalmanFilter};
 
 #[cfg(feature = "nalgebra")]
 pub use filter::StaticKalmanFilter;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -210,14 +210,14 @@ impl<T: KalmanScalar> fmt::Display for InnovationFormatter<'_, T> {
 /// Log filter dimensions for initialization
 pub fn log_filter_dimensions(state_dim: usize, measurement_dim: usize, control_dim: Option<usize>) {
     if let Some(control) = control_dim {
-        log::info!(
+        log::debug!(
             "Initializing Kalman filter: state_dim={}, measurement_dim={}, control_dim={}",
             state_dim,
             measurement_dim,
             control
         );
     } else {
-        log::info!(
+        log::debug!(
             "Initializing Kalman filter: state_dim={}, measurement_dim={}",
             state_dim,
             measurement_dim

--- a/src/particle/filter.rs
+++ b/src/particle/filter.rs
@@ -101,7 +101,7 @@ where
         dt: T,
     ) -> KalmanResult<Self> {
         log_filter_dimensions(state_dim, measurement_noise_std.len(), None);
-        info!(
+        debug!(
             "Particle Filter: Initializing with {} particles",
             num_particles
         );

--- a/src/scented.rs
+++ b/src/scented.rs
@@ -70,7 +70,10 @@ where
     S: NonlinearSystem<T>,
 {
     /// Create a new Cubature Kalman Filter
-    #[deprecated(since = "1.0.0-alpha0", note = "Use CubatureKalmanFilterBuilder instead")]
+    #[deprecated(
+        since = "1.0.0-alpha0",
+        note = "Use CubatureKalmanFilterBuilder instead"
+    )]
     pub fn new(
         system: S,
         initial_state: Vec<T>,
@@ -79,7 +82,15 @@ where
         measurement_noise: Vec<T>,
         dt: T,
     ) -> KalmanResult<Self> {
-        Self::initialize(system, initial_state, initial_covariance, process_noise, measurement_noise, dt, None)
+        Self::initialize(
+            system,
+            initial_state,
+            initial_covariance,
+            process_noise,
+            measurement_noise,
+            dt,
+            None,
+        )
     }
 
     /// Initialize a new Cubature Kalman Filter (internal method)

--- a/src/scented.rs
+++ b/src/scented.rs
@@ -107,7 +107,7 @@ where
         let m = system.measurement_dim();
 
         log_filter_dimensions(n, m, None);
-        info!(
+        debug!(
             "Cubature Kalman Filter: Initializing with {} cubature points",
             2 * n
         );

--- a/src/types.rs
+++ b/src/types.rs
@@ -59,9 +59,9 @@ pub enum JacobianStrategy {
     /// User provides analytical Jacobian functions
     Analytical,
     /// Compute Jacobian using finite differences
-    Numerical { 
+    Numerical {
         /// Step size for finite difference approximation
-        step_size: f64 
+        step_size: f64,
     },
     /// Use automatic differentiation (future enhancement)
     #[allow(dead_code)]

--- a/src/unscented.rs
+++ b/src/unscented.rs
@@ -756,11 +756,12 @@ mod tests {
             vec![0.01, 0.0, 0.0, 0.01],
             vec![0.1],
             0.01,
-        ).unwrap();
-        
+        )
+        .unwrap();
+
         // Generate sigma points internally
         ukf.generate_sigma_points().unwrap();
-        
+
         // Should have 2*n+1 = 5 sigma points(?) for n=2
         assert_eq!(ukf.sigma_points.len(), 10);
     }
@@ -774,15 +775,16 @@ mod tests {
             vec![0.01, 0.0, 0.0, 0.01],
             vec![0.1],
             0.01,
-        ).unwrap();
-        
+        )
+        .unwrap();
+
         // Weights should sum to 1 (testing with known default parameters)
         let n = 2;
         let lambda = ukf.params.alpha.powi(2) * (n as f64 + ukf.params.kappa) - n as f64;
         let weight_0_mean = lambda / (n as f64 + lambda);
         let weight_0_cov = weight_0_mean + (1.0 - ukf.params.alpha.powi(2) + ukf.params.beta);
         let weight_i = 0.5 / (n as f64 + lambda);
-        
+
         // Check first weight
         // assert!(weight_0_mean.abs() < 10.0); // Just sanity check
         assert!(weight_i > 0.0);
@@ -797,8 +799,9 @@ mod tests {
             vec![0.01, 0.0, 0.0, 0.01],
             vec![0.1],
             0.01,
-        ).unwrap();
-        
+        )
+        .unwrap();
+
         // Test parameter setters
         use crate::unscented::UKFParameters;
         let params = UKFParameters {
@@ -822,16 +825,17 @@ mod tests {
             vec![0.001, 0.0, 0.0, 0.001],
             vec![0.1],
             0.01,
-        ).unwrap();
-        
+        )
+        .unwrap();
+
         let true_state = vec![1.0, 0.5];
-        
+
         // Feed measurements
         for _ in 0..50 {
             ukf.predict().unwrap();
             ukf.update(&[true_state[0]]).unwrap();
         }
-        
+
         // // Should converge close to true state
         // assert!((ukf.state()[0] - true_state[0]).abs() < 0.2);
     }
@@ -840,12 +844,14 @@ mod tests {
     fn test_ukf_control_input() {
         struct ControlledNonlinear;
         impl NonlinearSystem<f64> for ControlledNonlinear {
-            fn state_transition(&self, state: &[f64], control: Option<&[f64]>, dt: f64) -> Vec<f64> {
+            fn state_transition(
+                &self,
+                state: &[f64],
+                control: Option<&[f64]>,
+                dt: f64,
+            ) -> Vec<f64> {
                 let u = control.map(|c| c[0]).unwrap_or(0.0);
-                vec![
-                    state[0] + state[1] * dt,
-                    state[1] + u * dt
-                ]
+                vec![state[0] + state[1] * dt, state[1] + u * dt]
             }
             fn measurement(&self, state: &[f64]) -> Vec<f64> {
                 vec![state[0]]
@@ -856,10 +862,14 @@ mod tests {
             fn measurement_jacobian(&self, _: &[f64]) -> Vec<f64> {
                 vec![1.0, 0.0]
             }
-            fn state_dim(&self) -> usize { 2 }
-            fn measurement_dim(&self) -> usize { 1 }
+            fn state_dim(&self) -> usize {
+                2
+            }
+            fn measurement_dim(&self) -> usize {
+                1
+            }
         }
-        
+
         let mut ukf = UnscentedKalmanFilter::new(
             ControlledNonlinear,
             vec![0.0, 0.0],
@@ -867,8 +877,9 @@ mod tests {
             vec![0.01, 0.0, 0.0, 0.01],
             vec![0.1],
             0.1,
-        ).unwrap();
-        
+        )
+        .unwrap();
+
         // Apply control
         ukf.set_control(vec![1.0]);
         ukf.predict().unwrap();
@@ -884,8 +895,9 @@ mod tests {
             vec![0.01, 0.0, 0.0, 0.01],
             vec![0.1],
             0.01,
-        ).unwrap();
-        
+        )
+        .unwrap();
+
         assert_eq!(ukf.state().len(), 2);
         assert_eq!(ukf.covariance().len(), 4);
         assert!((ukf.dt - 0.01).abs() < 1e-10);

--- a/tests/algorithm_validation.rs
+++ b/tests/algorithm_validation.rs
@@ -8,26 +8,26 @@ use kalman_filters::filter::KalmanFilter;
 fn test_static_convergence() {
     let true_value = 10.0_f64;
     let mut kf = KalmanFilter::new(1, 1);
-    
+
     // Initial guess (wrong)
     kf.x = vec![0.0];
     kf.P = vec![100.0]; // Large initial uncertainty
-    
+
     // Static system: x[k+1] = x[k]
     kf.F = vec![1.0];
     kf.H = vec![1.0];
     kf.Q = vec![0.0]; // No process noise (value is constant)
     kf.R = vec![1.0]; // Measurement noise
-    
+
     // Feed many measurements of the true value
     for _ in 0..50 {
         kf.predict();
         kf.update(&vec![true_value]).unwrap();
     }
-    
+
     // Should converge to true value
     assert_abs_diff_eq!(kf.x[0], true_value, epsilon = 0.1);
-    
+
     // Uncertainty should decrease
     assert!(kf.P[0] < 1.0, "Uncertainty didn't decrease: {}", kf.P[0]);
 }
@@ -37,41 +37,37 @@ fn test_static_convergence() {
 fn test_constant_velocity_tracking() {
     let dt = 0.1_f64;
     let true_velocity = 1.0;
-    
+
     let mut kf = KalmanFilter::new(2, 1);
-    
+
     // State: [position, velocity]
     kf.x = vec![0.0, 0.0];
-    kf.P = vec![
-        10.0, 0.0,
-        0.0,  10.0
-    ];
-    
+    kf.P = vec![10.0, 0.0, 0.0, 10.0];
+
     // Constant velocity dynamics
-    kf.F = vec![
-        1.0, dt,
-        0.0, 1.0
-    ];
-    
+    kf.F = vec![1.0, dt, 0.0, 1.0];
+
     // Observe position only
     kf.H = vec![1.0, 0.0];
-    
+
     // Small process noise
     kf.Q = vec![
-        0.01 * dt.powi(3) / 3.0, 0.01 * dt.powi(2) / 2.0,
-        0.01 * dt.powi(2) / 2.0, 0.01 * dt
+        0.01 * dt.powi(3) / 3.0,
+        0.01 * dt.powi(2) / 2.0,
+        0.01 * dt.powi(2) / 2.0,
+        0.01 * dt,
     ];
-    
+
     kf.R = vec![0.1];
-    
+
     // Track object moving at constant velocity
     for i in 1..=20 {
         kf.predict();
-        
+
         let true_position = true_velocity * (i as f64) * dt;
         kf.update(&vec![true_position]).unwrap();
     }
-    
+
     // Should estimate velocity correctly
     assert_abs_diff_eq!(kf.x[1], true_velocity, epsilon = 0.1);
 }
@@ -80,37 +76,28 @@ fn test_constant_velocity_tracking() {
 #[test]
 fn test_covariance_positive_definite() {
     let mut kf = KalmanFilter::new(2, 1);
-    
+
     kf.x = vec![0.0, 0.0];
-    kf.P = vec![
-        1.0, 0.0,
-        0.0, 1.0
-    ];
-    
-    kf.F = vec![
-        1.0, 0.1,
-        0.0, 1.0
-    ];
-    
+    kf.P = vec![1.0, 0.0, 0.0, 1.0];
+
+    kf.F = vec![1.0, 0.1, 0.0, 1.0];
+
     kf.H = vec![1.0, 0.0];
-    kf.Q = vec![
-        0.01, 0.0,
-        0.0,  0.01
-    ];
+    kf.Q = vec![0.01, 0.0, 0.0, 0.01];
     kf.R = vec![1.0];
-    
+
     for _ in 0..100 {
         kf.predict();
         kf.update(&vec![0.0]).unwrap();
-        
+
         // Check diagonal elements are positive
         assert!(kf.P[0] > 0.0, "P[0,0] not positive: {}", kf.P[0]);
         assert!(kf.P[3] > 0.0, "P[1,1] not positive: {}", kf.P[3]);
-        
+
         // Check determinant is positive (for 2x2)
         let det = kf.P[0] * kf.P[3] - kf.P[1] * kf.P[2];
         assert!(det > 0.0, "Covariance determinant not positive: {}", det);
-        
+
         // Check symmetry
         assert_abs_diff_eq!(kf.P[1], kf.P[2], epsilon = 1e-10);
     }
@@ -120,25 +107,26 @@ fn test_covariance_positive_definite() {
 #[test]
 fn test_measurement_reduces_uncertainty() {
     let mut kf = KalmanFilter::new(1, 1);
-    
+
     kf.x = vec![0.0];
     kf.P = vec![10.0];
     kf.F = vec![1.0];
     kf.H = vec![1.0];
     kf.Q = vec![0.1];
     kf.R = vec![1.0];
-    
+
     kf.predict();
     let p_after_predict = kf.P[0];
-    
+
     kf.update(&vec![5.0]).unwrap();
     let p_after_update = kf.P[0];
-    
+
     // Measurement should reduce uncertainty
     assert!(
         p_after_update < p_after_predict,
         "Measurement didn't reduce uncertainty: {} >= {}",
-        p_after_update, p_after_predict
+        p_after_update,
+        p_after_predict
     );
 }
 
@@ -146,47 +134,39 @@ fn test_measurement_reduces_uncertainty() {
 #[test]
 fn test_steady_state() {
     let mut kf = KalmanFilter::new(2, 1);
-    
+
     kf.x = vec![0.0, 0.0];
-    kf.P = vec![
-        100.0, 0.0,
-        0.0,   100.0
-    ];
-    
-    kf.F = vec![
-        1.0, 0.1,
-        0.0, 1.0
-    ];
-    
+    kf.P = vec![100.0, 0.0, 0.0, 100.0];
+
+    kf.F = vec![1.0, 0.1, 0.0, 1.0];
+
     kf.H = vec![1.0, 0.0];
-    kf.Q = vec![
-        0.01, 0.0,
-        0.0,  0.01
-    ];
+    kf.Q = vec![0.01, 0.0, 0.0, 0.01];
     kf.R = vec![1.0];
-    
+
     let mut prev_p = kf.P.clone();
     let mut converged = false;
-    
+
     for i in 0..500 {
         kf.predict();
         kf.update(&vec![0.0]).unwrap();
-        
+
         // Check if covariance has converged
-        let max_diff = kf.P.iter()
-            .zip(prev_p.iter())
-            .map(|(a, b): (&f64, &f64)| (a - b).abs())
-            .fold(0.0_f64, f64::max);
-        
+        let max_diff =
+            kf.P.iter()
+                .zip(prev_p.iter())
+                .map(|(a, b): (&f64, &f64)| (a - b).abs())
+                .fold(0.0_f64, f64::max);
+
         if max_diff < 1e-8 {
             converged = true;
             println!("Converged at iteration {}", i);
             break;
         }
-        
+
         prev_p = kf.P.clone();
     }
-    
+
     assert!(converged, "Filter didn't reach steady state");
 }
 
@@ -196,16 +176,16 @@ fn test_numerical_stability() {
     // Test with very small values - but not so small they cause singularity
     let mut kf = KalmanFilter::new(1, 1);
     kf.x = vec![1e-8f64];
-    kf.P = vec![1e-10f64];  // Small but not singular
+    kf.P = vec![1e-10f64]; // Small but not singular
     kf.F = vec![1.0f64];
     kf.H = vec![1.0f64];
     kf.Q = vec![1e-12f64];
-    kf.R = vec![1e-10f64];  // Measurement noise can't be too small
-    
+    kf.R = vec![1e-10f64]; // Measurement noise can't be too small
+
     for _ in 0..10 {
         kf.predict();
         let result = kf.update(&vec![1e-8]);
-        
+
         // It's OK if update fails with singular matrix for extreme values
         // The important thing is it doesn't panic or produce NaN
         if result.is_ok() {
@@ -213,7 +193,7 @@ fn test_numerical_stability() {
             assert!(!kf.P[0].is_nan(), "Covariance became NaN");
         }
     }
-    
+
     // Test with very large values
     let mut kf = KalmanFilter::new(1, 1);
     kf.x = vec![1e10f64];
@@ -225,7 +205,7 @@ fn test_numerical_stability() {
 
     kf.predict();
     kf.update(&vec![1e10]).unwrap();
-    
+
     assert!(!kf.x[0].is_infinite(), "State became infinite");
 }
 
@@ -233,47 +213,38 @@ fn test_numerical_stability() {
 #[test]
 fn test_unobservable_state() {
     let mut kf: KalmanFilter<f64> = KalmanFilter::new(2, 1);
-    
+
     // Wrong initial guess
     kf.x = vec![10.0, 20.0];
-    kf.P = vec![
-        100.0, 0.0,
-        0.0,   100.0
-    ];
-    
+    kf.P = vec![100.0, 0.0, 0.0, 100.0];
+
     // Identity dynamics
-    kf.F = vec![
-        1.0, 0.0,
-        0.0, 1.0
-    ];
-    
+    kf.F = vec![1.0, 0.0, 0.0, 1.0];
+
     // Only observe first state
     kf.H = vec![1.0, 0.0];
-    
-    kf.Q = vec![
-        0.01, 0.0,
-        0.0,  0.01
-    ];
+
+    kf.Q = vec![0.01, 0.0, 0.0, 0.01];
     kf.R = vec![0.1];
-    
+
     let initial_p22 = kf.P[3];
-    
+
     // Many updates with true state [0, 0]
     for _ in 0..100 {
         kf.predict();
         kf.update(&vec![0.0]).unwrap();
     }
-    
+
     // First state should converge
     assert_abs_diff_eq!(kf.x[0], 0.0, epsilon = 1.0);
-    
+
     // Second state should not converge (unobservable)
     assert!(
         kf.x[1].abs() > 5.0,
         "Unobservable state converged: {}",
         kf.x[1]
     );
-    
+
     // Uncertainty of unobservable state should grow
     assert!(
         kf.P[3] > initial_p22,

--- a/tests/builder_tests.rs
+++ b/tests/builder_tests.rs
@@ -6,21 +6,25 @@ use kalman_filters::*;
 struct TestSystem;
 
 impl NonlinearSystem<f64> for TestSystem {
-    fn state_dim(&self) -> usize { 2 }
-    fn measurement_dim(&self) -> usize { 1 }
-    
+    fn state_dim(&self) -> usize {
+        2
+    }
+    fn measurement_dim(&self) -> usize {
+        1
+    }
+
     fn state_transition(&self, state: &[f64], _control: Option<&[f64]>, dt: f64) -> Vec<f64> {
         vec![state[0] + state[1] * dt, state[1]]
     }
-    
+
     fn measurement(&self, state: &[f64]) -> Vec<f64> {
         vec![state[0]]
     }
-    
+
     fn state_jacobian(&self, _state: &[f64], _control: Option<&[f64]>, _dt: f64) -> Vec<f64> {
         vec![1.0, 0.0, 0.0, 1.0]
     }
-    
+
     fn measurement_jacobian(&self, _state: &[f64]) -> Vec<f64> {
         vec![1.0, 0.0]
     }
@@ -29,7 +33,7 @@ impl NonlinearSystem<f64> for TestSystem {
 #[test]
 fn test_extended_kalman_filter_builder() {
     let system = TestSystem;
-    
+
     let ekf = ExtendedKalmanFilterBuilder::new(system)
         .initial_state(vec![0.0, 1.0])
         .initial_covariance(vec![1.0, 0.0, 0.0, 1.0])
@@ -38,7 +42,7 @@ fn test_extended_kalman_filter_builder() {
         .dt(0.1)
         .build()
         .unwrap();
-    
+
     assert_eq!(ekf.state().len(), 2);
     assert_eq!(ekf.covariance().len(), 4);
 }
@@ -46,7 +50,7 @@ fn test_extended_kalman_filter_builder() {
 #[test]
 fn test_unscented_kalman_filter_builder() {
     let system = TestSystem;
-    
+
     let ukf = UnscentedKalmanFilterBuilder::new(system)
         .initial_state(vec![0.0, 1.0])
         .initial_covariance(vec![1.0, 0.0, 0.0, 1.0])
@@ -58,7 +62,7 @@ fn test_unscented_kalman_filter_builder() {
         .kappa(0.0)
         .build()
         .unwrap();
-    
+
     assert_eq!(ukf.state().len(), 2);
     assert_eq!(ukf.covariance().len(), 4);
 }
@@ -66,7 +70,7 @@ fn test_unscented_kalman_filter_builder() {
 #[test]
 fn test_cubature_kalman_filter_builder() {
     let system = TestSystem;
-    
+
     let ckf = CubatureKalmanFilterBuilder::new(system)
         .initial_state(vec![0.0, 1.0])
         .initial_covariance(vec![1.0, 0.0, 0.0, 1.0])
@@ -75,7 +79,7 @@ fn test_cubature_kalman_filter_builder() {
         .dt(0.1)
         .build()
         .unwrap();
-    
+
     assert_eq!(ckf.state().len(), 2);
     assert_eq!(ckf.covariance().len(), 4);
 }
@@ -83,7 +87,7 @@ fn test_cubature_kalman_filter_builder() {
 #[test]
 fn test_ensemble_kalman_filter_builder() {
     let system = TestSystem;
-    
+
     let enkf = EnsembleKalmanFilterBuilder::new(system)
         .initial_mean(vec![0.0, 1.0])
         .initial_spread(vec![1.0, 1.0])
@@ -94,7 +98,7 @@ fn test_ensemble_kalman_filter_builder() {
         .inflation_factor(1.05)
         .build()
         .unwrap();
-    
+
     assert_eq!(enkf.mean().len(), 2);
     assert_eq!(enkf.ensemble_size, 50);
 }
@@ -110,7 +114,7 @@ fn test_information_filter_builder() {
         .measurement_noise(vec![0.1])
         .build()
         .unwrap();
-    
+
     let state = if_filter.get_state().unwrap();
     assert_eq!(state.len(), 2);
 }
@@ -119,7 +123,7 @@ fn test_information_filter_builder() {
 fn test_information_filter_builder_from_state_covariance() {
     let initial_state = vec![1.0, 2.0];
     let initial_covariance = vec![2.0, 0.5, 0.5, 1.0];
-    
+
     let if_filter = InformationFilterBuilder::from_state_covariance(
         initial_state.clone(),
         initial_covariance,
@@ -132,7 +136,7 @@ fn test_information_filter_builder_from_state_covariance() {
     .measurement_noise(vec![0.1])
     .build()
     .unwrap();
-    
+
     let recovered_state = if_filter.get_state().unwrap();
     let diff0: f64 = recovered_state[0] - initial_state[0];
     let diff1: f64 = recovered_state[1] - initial_state[1];
@@ -151,7 +155,7 @@ fn test_particle_filter_builder() {
         .ess_threshold(50.0)
         .build()
         .unwrap();
-    
+
     assert_eq!(pf.state_dim, 2);
     assert_eq!(pf.num_particles, 100);
     assert_eq!(pf.ess_threshold, 50.0);
@@ -160,13 +164,13 @@ fn test_particle_filter_builder() {
 #[test]
 fn test_builder_incomplete() {
     let system = TestSystem;
-    
+
     // Test missing required parameter
     let result = ExtendedKalmanFilterBuilder::new(system)
         .initial_state(vec![0.0, 1.0])
         // Missing other required fields
         .build();
-    
+
     assert!(result.is_err());
     if let Err(KalmanError::BuilderIncomplete(field)) = result {
         assert_eq!(field, "initial_covariance");

--- a/tests/information_tests.rs
+++ b/tests/information_tests.rs
@@ -3,13 +3,11 @@
 
 use kalman_filters::filter::KalmanFilter;
 use kalman_filters::information::{
-    InformationFilter, InformationState, InformationForm,
-    kalman_to_information, information_to_kalman,
-    SparseInformationFilter,
+    consensus::{AverageConsensus, ConsensusAlgorithm, WeightedConsensus},
+    information_to_kalman, kalman_to_information,
     sparse::SparseMatrix,
-    ExtendedInformationFilter,
-    DistributedInformationFilter,
-    consensus::{AverageConsensus, WeightedConsensus, ConsensusAlgorithm},
+    DistributedInformationFilter, ExtendedInformationFilter, InformationFilter, InformationForm,
+    InformationState, SparseInformationFilter,
 };
 use kalman_filters::types::NonlinearSystem;
 use rand::Rng;
@@ -22,44 +20,54 @@ const EPSILON: f64 = 1e-10;
 fn test_kf_if_equivalence() {
     // Create identical filters
     let mut kf = KalmanFilter::<f64>::initialize(
-        2, 1,
+        2,
+        1,
         vec![0.0, 0.0],
         vec![1.0, 0.0, 0.0, 1.0],
         vec![1.0, 0.1, 0.0, 1.0],
         vec![0.01, 0.0, 0.0, 0.01],
         vec![1.0, 0.0],
         vec![0.1],
-    ).unwrap();
-    
+    )
+    .unwrap();
+
     let mut inf = kalman_to_information(&kf).unwrap();
-    
+
     // Perform identical operations
     for i in 0..5 {
         kf.predict();
         kf.update(&[i as f64]).unwrap();
-        
+
         inf.predict().unwrap();
         inf.update(&[i as f64]).unwrap();
     }
-    
+
     // Compare final states
     let kf_state = kf.state();
     let inf_state = inf.get_state().unwrap();
-    
+
     for i in 0..2 {
-        assert!((kf_state[i] - inf_state[i]).abs() < EPSILON,
-                "State mismatch at index {}: KF={}, IF={}", 
-                i, kf_state[i], inf_state[i]);
+        assert!(
+            (kf_state[i] - inf_state[i]).abs() < EPSILON,
+            "State mismatch at index {}: KF={}, IF={}",
+            i,
+            kf_state[i],
+            inf_state[i]
+        );
     }
-    
+
     // Compare covariances
     let kf_cov = kf.covariance();
     let inf_cov = inf.get_covariance().unwrap();
-    
+
     for i in 0..4 {
-        assert!((kf_cov[i] - inf_cov[i]).abs() < EPSILON,
-                "Covariance mismatch at index {}: KF={}, IF={}", 
-                i, kf_cov[i], inf_cov[i]);
+        assert!(
+            (kf_cov[i] - inf_cov[i]).abs() < EPSILON,
+            "Covariance mismatch at index {}: KF={}, IF={}",
+            i,
+            kf_cov[i],
+            inf_cov[i]
+        );
     }
 }
 
@@ -68,22 +76,24 @@ fn test_kf_if_equivalence() {
 fn test_if_no_measurement() {
     let Y_init = vec![1.0, 0.0, 0.0, 1.0];
     let y_init = vec![0.0, 0.0];
-    
+
     let mut inf = InformationFilter::new(
-        2, 1,
+        2,
+        1,
         Y_init.clone(),
         y_init.clone(),
         vec![1.0, 0.1, 0.0, 1.0],
         vec![0.01, 0.0, 0.0, 0.01],
         vec![1.0, 0.0],
         vec![0.1],
-    ).unwrap();
-    
+    )
+    .unwrap();
+
     // Predict without update (key advantage of IF)
     inf.predict().unwrap();
-    inf.skip_update();  // No measurement
+    inf.skip_update(); // No measurement
     inf.predict().unwrap();
-    
+
     // Information should decrease (uncertainty increases)
     assert!(inf.state.Y[0] < Y_init[0]);
 }
@@ -92,24 +102,26 @@ fn test_if_no_measurement() {
 #[test]
 fn test_multiple_sensor_fusion() {
     let mut inf = InformationFilter::new(
-        2, 1,
+        2,
+        1,
         vec![1.0, 0.0, 0.0, 1.0],
         vec![0.0, 0.0],
         vec![1.0, 0.0, 0.0, 1.0],
         vec![0.01, 0.0, 0.0, 0.01],
         vec![1.0, 0.0],
         vec![0.1],
-    ).unwrap();
-    
+    )
+    .unwrap();
+
     // Multiple measurements from different sensors
     let measurements = vec![
-        (&[1.0][..], &[1.0, 0.0][..], &[0.1][..]),      // Sensor 1
-        (&[0.9][..], &[1.0, 0.0][..], &[0.2][..]),      // Sensor 2 (noisier)
-        (&[1.1][..], &[0.0, 1.0][..], &[0.15][..]),     // Sensor 3 (observes velocity)
+        (&[1.0][..], &[1.0, 0.0][..], &[0.1][..]),  // Sensor 1
+        (&[0.9][..], &[1.0, 0.0][..], &[0.2][..]),  // Sensor 2 (noisier)
+        (&[1.1][..], &[0.0, 1.0][..], &[0.15][..]), // Sensor 3 (observes velocity)
     ];
-    
+
     inf.fuse_measurements(measurements).unwrap();
-    
+
     // State should be close to average of measurements
     let state = inf.get_state().unwrap();
     assert!((state[0] - 1.0f64).abs() < 0.2f64);
@@ -120,60 +132,52 @@ fn test_multiple_sensor_fusion() {
 fn test_sparse_matrix() {
     // Create a highly sparse matrix
     let dense = vec![
-        1.0, 0.0, 0.0, 0.0, 2.0,
-        0.0, 3.0, 0.0, 0.0, 0.0,
-        0.0, 0.0, 0.0, 0.0, 0.0,
-        0.0, 0.0, 0.0, 4.0, 0.0,
-        5.0, 0.0, 0.0, 0.0, 6.0,
+        1.0, 0.0, 0.0, 0.0, 2.0, 0.0, 3.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        4.0, 0.0, 5.0, 0.0, 0.0, 0.0, 6.0,
     ];
-    
+
     let sparse = SparseMatrix::from_dense(&dense, 5, 5);
-    
+
     // Check sparsity
-    assert!(sparse.sparsity() > 0.7);  // >70% sparse
-    assert_eq!(sparse.values.len(), 6);  // Only 6 non-zeros
-    
+    assert!(sparse.sparsity() > 0.7); // >70% sparse
+    assert_eq!(sparse.values.len(), 6); // Only 6 non-zeros
+
     // Test matrix-vector multiplication
     let v = vec![1.0, 2.0, 3.0, 4.0, 5.0];
     let result = sparse.multiply_vector(&v).unwrap();
-    
+
     // Verify result
-    assert_eq!(result[0], 1.0 * 1.0 + 2.0 * 5.0);  // 11.0
-    assert_eq!(result[1], 3.0 * 2.0);              // 6.0
-    assert_eq!(result[2], 0.0);                     // 0.0
-    assert_eq!(result[3], 4.0 * 4.0);              // 16.0
-    assert_eq!(result[4], 5.0 * 1.0 + 6.0 * 5.0);  // 35.0
+    assert_eq!(result[0], 1.0 * 1.0 + 2.0 * 5.0); // 11.0
+    assert_eq!(result[1], 3.0 * 2.0); // 6.0
+    assert_eq!(result[2], 0.0); // 0.0
+    assert_eq!(result[3], 4.0 * 4.0); // 16.0
+    assert_eq!(result[4], 5.0 * 1.0 + 6.0 * 5.0); // 35.0
 }
 
 /// Test sparse Information Filter
 #[test]
 fn test_sparse_information_filter() {
     let mut sif = SparseInformationFilter::new(
-        6,  // 6-dimensional state
+        6,              // 6-dimensional state
         vec![0.1; 36],  // Initial Y
         vec![0.0; 6],   // Initial y
         vec![1.0; 36],  // F (identity for simplicity)
         vec![0.01; 36], // Q
-    ).unwrap();
-    
+    )
+    .unwrap();
+
     // Register sparse sensor (observes only states 0, 2, 4)
     let H_dense = vec![
-        1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-        0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
-        0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+        1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
     ];
     let H_sparse = SparseMatrix::from_dense(&H_dense, 3, 6);
-    let R = vec![
-        0.1, 0.0, 0.0,
-        0.0, 0.1, 0.0,
-        0.0, 0.0, 0.1,
-    ];
-    
+    let R = vec![0.1, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.1];
+
     sif.register_sensor(1, H_sparse, R).unwrap();
-    
+
     // Update with sparse measurement
     sif.sparse_update(1, &[1.0, 2.0, 3.0]).unwrap();
-    
+
     // Check sparsity benefit
     let sparsity = sif.get_sensor_sparsity(1).unwrap();
     assert!(sparsity > 0.7);
@@ -189,34 +193,35 @@ impl NonlinearSystem<f64> for SimpleNonlinear {
             state[1] - 0.1 * state[0].sin() * dt,
         ]
     }
-    
+
     fn measurement(&self, state: &[f64]) -> Vec<f64> {
-        vec![state[0].powi(2) + state[1].powi(2)]  // Range measurement
+        vec![state[0].powi(2) + state[1].powi(2)] // Range measurement
     }
-    
+
     fn state_jacobian(&self, state: &[f64], _control: Option<&[f64]>, dt: f64) -> Vec<f64> {
-        vec![
-            1.0, dt,
-            -0.1 * state[0].cos() * dt, 1.0,
-        ]
+        vec![1.0, dt, -0.1 * state[0].cos() * dt, 1.0]
     }
-    
+
     fn measurement_jacobian(&self, state: &[f64]) -> Vec<f64> {
         vec![2.0 * state[0], 2.0 * state[1]]
     }
-    
-    fn state_dim(&self) -> usize { 2 }
-    fn measurement_dim(&self) -> usize { 1 }
+
+    fn state_dim(&self) -> usize {
+        2
+    }
+    fn measurement_dim(&self) -> usize {
+        1
+    }
 }
 
 /// Test Extended Information Filter
 #[test]
 fn test_extended_information_filter() {
     let system = SimpleNonlinear;
-    
+
     let Y_init = vec![100.0, 0.0, 0.0, 100.0];
-    let y_init = vec![10.0, 5.0];  // x ≈ 0.1, 0.05
-    
+    let y_init = vec![10.0, 5.0]; // x ≈ 0.1, 0.05
+
     let mut eif = ExtendedInformationFilter::new(
         system,
         Y_init,
@@ -224,14 +229,15 @@ fn test_extended_information_filter() {
         vec![0.001, 0.0, 0.0, 0.001],
         vec![0.01],
         0.1,
-    ).unwrap();
-    
+    )
+    .unwrap();
+
     // Predict and update
     eif.predict().unwrap();
-    eif.update(&[0.02]).unwrap();  // Measurement of range^2
-    
+    eif.update(&[0.02]).unwrap(); // Measurement of range^2
+
     let state = eif.get_state().unwrap();
-    assert!(state[0].abs() < 0.2);  // Should be small
+    assert!(state[0].abs() < 0.2); // Should be small
 }
 
 /// Test distributed Information Filter
@@ -239,30 +245,30 @@ fn test_extended_information_filter() {
 fn test_distributed_filter() {
     // Create 4-node network in square topology
     let mut dif = DistributedInformationFilter::<f64>::new(2);
-    
+
     let Y_init = vec![1.0, 0.0, 0.0, 1.0];
     let y_init = vec![0.0, 0.0];
-    
+
     for i in 0..4 {
         dif.add_node(i, Y_init.clone(), y_init.clone()).unwrap();
     }
-    
+
     // Connect as square: 0-1, 1-2, 2-3, 3-0
     dif.connect_nodes(0, 1, 0).unwrap();
     dif.connect_nodes(1, 2, 0).unwrap();
     dif.connect_nodes(2, 3, 0).unwrap();
     dif.connect_nodes(3, 0, 0).unwrap();
-    
+
     // Node 0 makes measurement
     let H = vec![1.0, 0.0];
     let R = vec![0.1];
     dif.local_update(0, &[1.0], &H, &R).unwrap();
-    
+
     // Propagate information
     for _ in 0..4 {
         dif.process_messages().unwrap();
     }
-    
+
     // All nodes should have received information
     for i in 0..4 {
         let state = dif.get_node_state(i).unwrap();
@@ -278,59 +284,67 @@ fn test_consensus_algorithms() {
     topology.insert(0, vec![1, 2]);
     topology.insert(1, vec![0, 2]);
     topology.insert(2, vec![0, 1]);
-    
+
     // Test average consensus
     {
         let mut consensus = AverageConsensus::<f64>::new_metropolis(&topology, 2);
-        
+
         let mut states = HashMap::new();
-        states.insert(0, InformationState::from_information(
-            vec![3.0, 0.0, 0.0, 3.0],
-            vec![3.0, 0.0],
-        ).unwrap());
-        states.insert(1, InformationState::from_information(
-            vec![2.0, 0.0, 0.0, 2.0],
-            vec![2.0, 0.0],
-        ).unwrap());
-        states.insert(2, InformationState::from_information(
-            vec![1.0, 0.0, 0.0, 1.0],
-            vec![1.0, 0.0],
-        ).unwrap());
-        
+        states.insert(
+            0,
+            InformationState::from_information(vec![3.0, 0.0, 0.0, 3.0], vec![3.0, 0.0]).unwrap(),
+        );
+        states.insert(
+            1,
+            InformationState::from_information(vec![2.0, 0.0, 0.0, 2.0], vec![2.0, 0.0]).unwrap(),
+        );
+        states.insert(
+            2,
+            InformationState::from_information(vec![1.0, 0.0, 0.0, 1.0], vec![1.0, 0.0]).unwrap(),
+        );
+
         // Run consensus
         for _ in 0..20 {
             consensus.iterate(&mut states, &topology).unwrap();
         }
-        
+
         assert!(consensus.is_converged(0.01));
-        
+
         // Check convergence to average
         let avg = consensus.get_consensus().unwrap();
-        assert!((avg.Y[0] - 2.0).abs() < 0.1);  // Average of [3, 2, 1]
+        assert!((avg.Y[0] - 2.0).abs() < 0.1); // Average of [3, 2, 1]
     }
-    
+
     // Test weighted consensus
     {
         let mut consensus = WeightedConsensus::<f64>::new(2);
-        
+
         let mut states = HashMap::new();
-        states.insert(0, InformationState::from_information(
-            vec![10.0, 0.0, 0.0, 10.0],  // High confidence
-            vec![10.0, 0.0],
-        ).unwrap());
-        states.insert(1, InformationState::from_information(
-            vec![1.0, 0.0, 0.0, 1.0],    // Low confidence
-            vec![5.0, 0.0],
-        ).unwrap());
-        
+        states.insert(
+            0,
+            InformationState::from_information(
+                vec![10.0, 0.0, 0.0, 10.0], // High confidence
+                vec![10.0, 0.0],
+            )
+            .unwrap(),
+        );
+        states.insert(
+            1,
+            InformationState::from_information(
+                vec![1.0, 0.0, 0.0, 1.0], // Low confidence
+                vec![5.0, 0.0],
+            )
+            .unwrap(),
+        );
+
         consensus.iterate(&mut states, &topology).unwrap();
-        
+
         // Should be weighted toward high-confidence node
         let result = consensus.get_consensus().unwrap();
         // The weighted consensus should combine the information vectors
         // High confidence node has y = [10, 0], low confidence has y = [5, 0]
         // Result should be weighted average closer to high confidence value
-        assert!(result.y[0] > 5.0);  // Weighted average favoring high-confidence node
+        assert!(result.y[0] > 5.0); // Weighted average favoring high-confidence node
     }
 }
 
@@ -339,25 +353,23 @@ fn test_consensus_algorithms() {
 fn test_form_conversion() {
     // Start with KF
     let kf = KalmanFilter::<f64>::initialize(
-        3, 2,
+        3,
+        2,
         vec![1.0, 2.0, 3.0],
-        vec![
-            2.0, 0.5, 0.1,
-            0.5, 1.5, 0.2,
-            0.1, 0.2, 1.0,
-        ],
+        vec![2.0, 0.5, 0.1, 0.5, 1.5, 0.2, 0.1, 0.2, 1.0],
         vec![1.0; 9],
         vec![0.01; 9],
         vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
         vec![0.1, 0.0, 0.0, 0.1],
-    ).unwrap();
-    
+    )
+    .unwrap();
+
     // Convert to IF
     let inf = kalman_to_information(&kf).unwrap();
-    
+
     // Convert back to KF
     let kf2 = information_to_kalman(&inf).unwrap();
-    
+
     // Check equivalence
     for i in 0..3 {
         assert!((kf.x[i] - kf2.x[i]).abs() < EPSILON);
@@ -373,56 +385,55 @@ fn test_information_addition() {
     let mut state = InformationState::<f64>::new(2);
     state.Y = vec![1.0, 0.0, 0.0, 1.0];
     state.y = vec![0.0, 0.0];
-    
+
     // Add information from measurement 1
     let delta_Y1 = vec![2.0, 0.0, 0.0, 2.0];
     let delta_y1 = vec![2.0, 0.0];
     state.add_information(&delta_y1, &delta_Y1);
-    
+
     // Add information from measurement 2
     let delta_Y2 = vec![1.0, 0.0, 0.0, 1.0];
     let delta_y2 = vec![1.0, 0.0];
     state.add_information(&delta_y2, &delta_Y2);
-    
+
     // Check additive property
-    assert_eq!(state.Y[0], 4.0);  // 1 + 2 + 1
-    assert_eq!(state.y[0], 3.0);  // 0 + 2 + 1
+    assert_eq!(state.Y[0], 4.0); // 1 + 2 + 1
+    assert_eq!(state.y[0], 3.0); // 0 + 2 + 1
 }
 
 /// Test numerical stability
 #[test]
 fn test_numerical_stability() {
     // Test with nearly singular information matrix
-    let Y_init = vec![
-        1e-10, 0.0,
-        0.0, 1.0,
-    ];
+    let Y_init = vec![1e-10, 0.0, 0.0, 1.0];
     let y_init = vec![0.0, 1.0];
-    
+
     let mut inf = InformationFilter::new(
-        2, 1,
+        2,
+        1,
         Y_init,
         y_init,
         vec![1.0, 0.0, 0.0, 1.0],
         vec![0.01, 0.0, 0.0, 0.01],
-        vec![0.0, 1.0],  // Only observes second state
+        vec![0.0, 1.0], // Only observes second state
         vec![0.1],
-    ).unwrap();
-    
+    )
+    .unwrap();
+
     // Should handle prediction despite poor observability of first state
     let result = inf.predict();
-    assert!(result.is_ok() || result.is_err());  // May fail gracefully
+    assert!(result.is_ok() || result.is_err()); // May fail gracefully
 }
 
 /// Benchmark sparse vs dense operations
 #[test]
-#[ignore]  // Run with --ignored for benchmarks
+#[ignore] // Run with --ignored for benchmarks
 fn bench_sparse_vs_dense() {
     use std::time::Instant;
-    
-    let n = 100;  // Large state dimension
-    let sparsity = 0.95;  // 95% sparse
-    
+
+    let n = 100; // Large state dimension
+    let sparsity = 0.95; // 95% sparse
+
     // Create sparse matrix
     let mut dense = vec![0.0; n * n];
     let mut rng = rand::thread_rng();
@@ -433,17 +444,17 @@ fn bench_sparse_vs_dense() {
             }
         }
     }
-    
+
     let sparse = SparseMatrix::from_dense(&dense, n, n);
     let v = vec![1.0; n];
-    
+
     // Benchmark sparse multiplication
     let start = Instant::now();
     for _ in 0..1000 {
         let _ = sparse.multiply_vector(&v).unwrap();
     }
     let sparse_time = start.elapsed();
-    
+
     // Benchmark dense multiplication
     let start = Instant::now();
     for _ in 0..1000 {
@@ -455,11 +466,14 @@ fn bench_sparse_vs_dense() {
         }
     }
     let dense_time = start.elapsed();
-    
+
     println!("Sparse time: {:?}", sparse_time);
     println!("Dense time: {:?}", dense_time);
-    println!("Speedup: {:.2}x", dense_time.as_secs_f64() / sparse_time.as_secs_f64());
-    
+    println!(
+        "Speedup: {:.2}x",
+        dense_time.as_secs_f64() / sparse_time.as_secs_f64()
+    );
+
     // Sparse should be faster for high sparsity
     assert!(sparse_time < dense_time);
 }

--- a/tests/validation_tests.rs
+++ b/tests/validation_tests.rs
@@ -1,6 +1,5 @@
 // Main validation test suite that includes all validation modules
 // This allows running all validation tests with: cargo test --test validation_tests
 
-
 // Re-export all tests from the validation modules
 // This makes them discoverable by cargo test


### PR DESCRIPTION
Thank you for creating this library, I discovered 1h after you published it on crates.io when I was searching for a Kalman filter library. I've built https://github.com/qitechgmbh/mot with it.

When I was using my `bytetrack` in one of my applications, I noticed that the log level of this crate is quite verbose. I can manually ignore logs my this crate, but I thought it's a good idea to change all the `info` logs to `debug`.

This PR contains too many changes because it also includes `cargo fmt` changes. So if you merge #1 or run `cargo fmt` yourself first, the changes will be clear.

